### PR TITLE
ProofTrace: add copyright and fix README typos

### DIFF
--- a/ProofTrace/README
+++ b/ProofTrace/README
@@ -1,6 +1,7 @@
 # ProofTrace: Modern Proof Steps Recording for HOL Light
 
-LICENSE: The usual Hol-light license applies.
+COPYRIGHT: (c) Copyright Stanislas Polu 2019
+LICENSE: The usual HOL Light license applies.
 
 ProofTrace is a lightweight proof steps recording solution for HOL Light. It
 modifies the HOL Light kernel by introducing a new `proof` type and attaching
@@ -35,8 +36,8 @@ JSON object that represents a demonstrated theorem with its integer index.
 
 ## `prooftrace.proofs`
 
-This file dumps the calculus rewrite that led to each `thm` demonstrated in the
-current HOL Light context. Arguments of rewrites are either previously
+This file dumps the calculus rewrites that led to each `thm` demonstrated in
+the current HOL Light context. Arguments of rewrites are either previously
 demonstrated `thm` (represented by their integer index) or an exogenous `term`
 represented by an explicit tree syntax.
 
@@ -53,8 +54,8 @@ represented by an explicit tree syntax.
 
 ## `prooftrace.names`
 
-This files associate named `thm` in the current context (this is based on
-parsing the entire HOL Light code subtree).
+This files associates named `thm` in the current context (this is based on
+parsing the entire HOL Light code subtree) to their proof index.
 
 ```
 {"id": 1837, "nm": "ABS_SIMP"}
@@ -92,6 +93,6 @@ associated proofs).
 # dump_proofs "ProofTrace/prooftrace.proofs";;
 # dump_names "ProofTrace/prooftrace.names";;
 
-(* Each of these steps may take a while. The generated files for a fresh *)
-(* hol.ml context is generally 8GB large. *)
+(* Each of these steps may take a while. The generated set of files for a    *)
+(* fresh hol.ml context is generally 8GB large.                              *)
 ```


### PR DESCRIPTION
Follow-up to https://github.com/jrh13/hol-light/pull/49