### PR TITLE
A fix for an OCaml >= 4.06 (?) bug in realanalysis.ml

### DIFF
--- a/Multivariate/realanalysis.ml
+++ b/Multivariate/realanalysis.ml
@@ -4364,7 +4364,7 @@ add_real_differentiation_theorems
     (MATCH_MP HAS_REAL_DERIVATIVE_CHAIN
               HAS_REAL_DERIVATIVE_ACS))));;
 
-let rec REAL_DIFF_CONV =
+let REAL_DIFF_CONV =
   let partfn tm = let l,r = dest_comb tm in mk_pair(lhand l,r)
   and is_deriv = can (term_match [] `(f has_real_derivative f') net`) in
   let rec REAL_DIFF_CONV tm =


### PR DESCRIPTION
I think it is an OCaml bug. It can be easily reproduced with the following code in OCaml (HOL Light is not required at all) (tested with OCaml 4.06.1 and 4.07):

```ocaml
let rec f =
  let s t = t in
  let rec f t = s t
  and g a = a in
  f;;

Gc.minor();;

f 0;;
```
This code crashes OCaml with "Segmentation fault: 11" (both the toplevel and the compiled code).