### PR TITLE
Remove dead code.

### DIFF
--- a/itab.ml
+++ b/itab.ml
@@ -32,8 +32,7 @@ let ITAUT_TAC =
   let RIGHT_REVERSIBLE_TAC = FIRST
    [CONJ_TAC;                                                     (* and     *)
     GEN_TAC;                                                      (* forall  *)
-    DISCH_TAC;                                                    (* implies *)
-    (fun gl -> CONV_TAC(K(IMPLICATE(snd gl))) gl);                (* not     *)
+    DISCH_TAC;                                                    (* implies; not *)
     EQ_TAC]                                                       (* iff     *)
   and LEFT_REVERSIBLE_TAC th gl = tryfind (fun ttac -> ttac th gl)
    [CONJUNCTS_THEN' ASSUME_TAC;                                   (* and    *)


### PR DESCRIPTION
DISCH_TAC already handles negation so the removed line is superfluous.

I tested this change by executing:

  ITAUT `a ==> ~(~a)`