### PR TITLE
Warn about backtrace recording in README

### DIFF
--- a/README
+++ b/README
@@ -142,7 +142,14 @@ be available for some platforms. First the basic approach:
 
         #
 
-(3) At the OCaml prompt '#', do '#use "hol.ml";;' (the '#' is part of the
+(3) Make sure backtrace recording is disabled in your OCaml system.
+    HOL Light makes heavy use of exceptions and leaving recording
+    enabled will significantly degrade the performance (slowdowns up
+    to 10x were observed). You can see if backtrace recording is enabled
+    by issuing 'Printexc.backtrace_status ();;' at the prompt '#'. To
+    disable exception recording, do 'Printexc.record_backtrace false;;'.
+
+(4) At the OCaml prompt '#', do '#use "hol.ml";;' (the '#' is part of the
     command, not the prompt) followed by a newline. This should rebuild
     all the core HOL Light theories, and terminate after a few minutes
     with the usual OCaml prompt, something like:


### PR DESCRIPTION
I was thinking my old laptop really needed to be replaced as it took it more than 20 minutes to load HOL Light. Some investigation revealed that all the time was spent recording backtraces. Disabling the recording brought down the loading time to 2 minutes.

This PR proposes to add a warning in the README about this potential issue. I will let you judge if it belongs where I inserted it.

Thanks!