### PR TITLE
Recursively fail when loading a file with errors

### DIFF
--- a/hol.ml
+++ b/hol.ml
@@ -45,8 +45,7 @@ Topdirs.dir_load Format.std_formatter (Filename.concat (!hol_dir) "pa_j.cmo");;
 
 let use_file s =
   if Toploop.use_file Format.std_formatter s then ()
-  else (Format.print_string("Error in included file "^s);
-        Format.print_newline());;
+  else failwith("Error in included file "^s);;
 
 let hol_expand_directory s =
   if s = "$" || s = "$/" then !hol_dir


### PR DESCRIPTION
When a file is loaded with a standard loading function (`loads`, `loadt`, or
`needs`) errors are merely flagged with a message on the terminal but the
loading function itself does not fail. This means that if `a.ml` loads `b.ml`
then `c.ml`, and `b.ml` has errors, `c.ml` will be loaded when HOL is most
likely in a broken state. To avoid this behavior, this PR makes `use_file`
itself fail when the loaded file has errors.