### PR TITLE
words: extend usimdN to allow returning a word of different size

### DIFF
--- a/Library/words.ml
+++ b/Library/words.ml
@@ -6460,7 +6460,7 @@ let WORD_IREDUCE_CONV =
 (* ------------------------------------------------------------------------- *)
 
 let usimd2 = new_definition
- `(usimd2:(N word->N word)->((N)tybit0)word->((N)tybit0) word) f x =
+ `(usimd2:(N word->M word)->((N)tybit0)word->((M)tybit0) word) f x =
     word_join (f (word_subword x (dimindex(:N),dimindex(:N))))
               (f (word_subword x (0,dimindex(:N))))`;;
 
@@ -6473,13 +6473,13 @@ let simd2 = new_definition
                  (word_subword y (0,dimindex(:N))))`;;
 
 let usimd4 = new_definition
- `usimd4 (f:N word->N word) = usimd2 (usimd2 f)`;;
+ `usimd4 (f:N word->M word) = usimd2 (usimd2 f)`;;
 
 let simd4 = new_definition
  `simd4 (f:N word->N word->N word) = simd2 (simd2 f)`;;
 
 let usimd8 = new_definition
- `usimd8 (f:N word->N word) = usimd2 (usimd4 f)`;;
+ `usimd8 (f:N word->M word) = usimd2 (usimd4 f)`;;
 
 let simd8 = new_definition
  `simd8 (f:N word->N word->N word) = simd2 (simd4 f)`;;
@@ -6491,7 +6491,7 @@ let simd16 = new_definition
  `simd16 (f:N word->N word->N word) = simd2 (simd8 f)`;;
 
 let USIMD2 = prove
- (`!(f:N word->N word) xhi xlo.
+ (`!(f:N word->M word) xhi xlo.
         usimd2 f (word_join xhi xlo) = word_join (f xhi) (f xlo)`,
   REPEAT GEN_TAC THEN REWRITE_TAC[usimd2] THEN BINOP_TAC THEN AP_TERM_TAC THEN
   REWRITE_TAC[WORD_EQ_BITS_ALT; BIT_WORD_SUBWORD; BIT_WORD_JOIN] THEN


### PR DESCRIPTION
This is a simple pull request that extends the usimdN functions in Library/words.ml to allow returning a word whose size is different from the input word size.

The updated functions are to be used in an upcoming new pull request in awslabs/s2n-bignum that adds formal definitions of new SIMD operations.