### PR TITLE
Let new_definition print free variables if any exist

### DIFF
--- a/fusion.ml
+++ b/fusion.ml
@@ -589,7 +589,9 @@ module Hol : Hol_kernel = struct
   let new_basic_definition tm =
     match tm with
       Comb(Comb(Const("=",_),Var(cname,ty)),r) ->
-        if not(freesin [] r) then failwith "new_definition: term not closed"
+        if not(freesin [] r) then
+          failwith ("new_definition: term not closed: " ^
+              (String.concat ", " (map (fun (Var (name,_)) -> name) (frees r))))
         else if not (subset (type_vars_in_term r) (tyvars ty))
         then failwith "new_definition: Type variables not reflected in constant"
         else let c = new_constant(cname,ty); Const(cname,ty) in


### PR DESCRIPTION
This patch makes `new_definition` print free variables if the definition contains any.

```
> let _ = new_definition `f x = x + y + z`;;
Exception: Failure "new_definition: term not closed: y, z".
```