### PR TITLE
Locate camlp5o.cma using Topfind if OCaml >= 4.14

### DIFF
--- a/README
+++ b/README
@@ -34,11 +34,13 @@ prerequisites is as simple as
 For other OSs, more work is involved. The Objective CAML (OCaml)
 implementation is a prerequisite for running HOL Light. HOL Light
 should work with any recent version of OCaml; I've tried it on at
-least 3.04, 3.06, 3.07+2, 3.08.1, 3.09.3, 3.10.0, 3.11.2 and 4.00.
+least 3.04, 3.06, 3.07+2, 3.08.1, 3.09.3, 3.10.0, 3.11.2, 4.00,
+4.05 and 4.14.
 However, for versions >= 3.10 (in 3.10 there was an incompatible
 change in the camlp4 preprocessor) you will also need to get camlp5
-(version >= 4.07). Installing both items of software should not be too
-difficult, depending on the platform.
+(version >= 4.07). For versions >= 4.14, you will need to get camlp5
+8.00 and ocamlfind. Installing these items should not be
+too difficult, depending on the platform.
 
  1. OCaml: there are packages for many Linux distributions. For
     example, on a debian derivative like Ubuntu, you may just need
@@ -89,6 +91,10 @@ difficult, depending on the platform.
     with just something like
 
         sudo apt-get install camlp5
+
+    or
+
+        opam install camlp5
 
     However, you may get a version in "transitional" instead of
     "strict" mode (do "camlp5 -pmode" to check which you have).
@@ -141,6 +147,10 @@ be available for some platforms. First the basic approach:
                 Objective Caml version 4.01.0
 
         #
+
+    If you are using OCaml 4.14, you need to create a top-level OCaml
+    using 'ocamlmktop -o ocaml-hol' and use 'ocaml-hol' because the default
+    'ocaml' does not have 'compiler-libs' that is necessary to run HOL Light.
 
 (3) At the OCaml prompt '#', do '#use "hol.ml";;' (the '#' is part of the
     command, not the prompt) followed by a newline. This should rebuild

--- a/hol.ml
+++ b/hol.ml
@@ -25,19 +25,6 @@ let hol_dir = ref
 let temp_path = ref "/tmp";;
 
 (* ------------------------------------------------------------------------- *)
-(* Load in parsing extensions.                                               *)
-(* For Ocaml < 3.10, use the built-in camlp4                                 *)
-(* and for Ocaml >= 3.10, use camlp5 instead.                                *)
-(* ------------------------------------------------------------------------- *)
-
-if let v = String.sub Sys.ocaml_version 0 4 in v >= "3.10"
-then (Topdirs.dir_directory "+camlp5";
-      Topdirs.dir_load Format.std_formatter "camlp5o.cma")
-else (Topdirs.dir_load Format.std_formatter "camlp4o.cma");;
-
-Topdirs.dir_load Format.std_formatter (Filename.concat (!hol_dir) "pa_j.cmo");;
-
-(* ------------------------------------------------------------------------- *)
 (* Load files from system and/or user-settable directories.                  *)
 (* Paths map initial "$/" to !hol_dir dynamically; use $$ to get the actual  *)
 (* $ character at the start of a directory.                                  *)
@@ -81,6 +68,25 @@ let needs s =
   let fileid = (Filename.basename s',Digest.file s') in
   if List.mem fileid (!loaded_files)
   then Format.print_string("File \""^s^"\" already loaded\n") else loadt s;;
+
+(* ------------------------------------------------------------------------- *)
+(* Load in parsing extensions.                                               *)
+(* For Ocaml < 3.10, use the built-in camlp4                                 *)
+(* and for Ocaml >= 3.10, use camlp5 instead.                                *)
+(* For Ocaml >= 4.14, use ocamlfind to locate camlp5.                        *)
+(* ------------------------------------------------------------------------- *)
+
+let ocaml_version = String.sub Sys.ocaml_version 0 4;;
+let version_ge_3_10 = ocaml_version >= "3.10";;
+let version_ge_4_14 = ocaml_version >= "4.14";;
+
+if version_ge_4_14
+then loads "load_camlp5_topfind.ml"
+else if version_ge_3_10
+then loads "load_camlp5.ml"
+else loads "load_camlp4.ml";;
+
+Topdirs.dir_load Format.std_formatter (Filename.concat (!hol_dir) "pa_j.cmo");;
 
 (* ------------------------------------------------------------------------- *)
 (* Various tweaks to OCaml and general library functions.                    *)

--- a/load_camlp4.ml
+++ b/load_camlp4.ml
@@ -1,0 +1,1 @@
+Topdirs.dir_load Format.std_formatter "camlp4o.cma";;

--- a/load_camlp5.ml
+++ b/load_camlp5.ml
@@ -1,0 +1,2 @@
+Topdirs.dir_directory "+camlp5";;
+Topdirs.dir_load Format.std_formatter "camlp5o.cma";;

--- a/load_camlp5_topfind.ml
+++ b/load_camlp5_topfind.ml
@@ -1,0 +1,4 @@
+Topdirs.dir_use Format.std_formatter "topfind";;
+Topfind.load_deeply ["camlp5"];;
+Topfind.load_deeply ["num"];;
+Topdirs.dir_load Format.std_formatter "camlp5o.cma";;


### PR DESCRIPTION
This patch locates camlp5o.cma via Topfind which is a module provided by
the `ocamlfind` package, if the ocaml version >= 4.14.
This enables running `ocaml -init hol.ml` successfully in OCaml 4.14, allowing running
`make proofs` in s2n-bignum successfully without any modification.

Also, this patch refactors the code that loads camlp by (1) creating the
three versions of camlp5 loader .ml files - load_camlp4.ml, load_camlp5.ml,
load_camlp5_topfind.ml - and (2) using `loads` to find the right one
according to the OCaml version.
Note that, in step (1), it isn't Makefile that picks the right version of
load_camlp*.ml (unlike the update_database*.ml case which is picked in Makefile)
because version comparison requires '>=' string comparison in sh which is hard
unless Bash extension is used: [stackoverflow](https://stackoverflow.com/questions/21294867/how-to-test-strings-for-lexicographic-less-than-or-equal-in-bash)

On top of this, load_camlp5_topfind.ml also loads "num" which is helpful when
it cannot be located when OCaml 4.14 is used.