### PR TITLE
Let define print free variables if any exist

### DIFF
--- a/nums.ml
+++ b/nums.ml
@@ -282,7 +282,8 @@ let new_specification =
     if not (asl = []) then
       failwith "new_specification: Assumptions not allowed in theorem" else
     if not (frees c = []) then
-      failwith "new_specification: Free variables in predicate" else
+      failwith ("new_specification: Free variables in predicate: " ^
+        (String.concat ", " (map (fun (Var (name,_)) -> name) (frees c)))) else
     let avs = fst(strip_exists c) in
     if length names = 0 || length names > length avs then
       failwith "new_specification: Unsuitable number of constant names" else


### PR DESCRIPTION
This is an extension of a932d698ff714861e88bd48c38e4b267ee4430e7 to make `define` print free variables if the definition contains any.

```
> let _ = define `f x = x + y + z`;;
Exception: Failure "new_specification: Free variables in predicate: y, z".
```