### PR TITLE
Don't load 'compiler-libs.common' in OCaml 4.14

### DIFF
--- a/load_camlp5_topfind.ml
+++ b/load_camlp5_topfind.ml
@@ -1,4 +1,9 @@
 Topdirs.dir_use Format.std_formatter "topfind";;
+
+(* Don't load compiler-libs.common because it conflicts with toplevel's Env. *)
+(* See also: https://github.com/ocaml/ocaml/issues/12271 *)
+Topfind.don't_load ["compiler-libs.common"];;
+
 Topfind.load_deeply ["camlp5"];;
 Topfind.load_deeply ["num"];;
 Topdirs.dir_load Format.std_formatter "camlp5o.cma";;

--- a/update_database_4.14.ml
+++ b/update_database_4.14.ml
@@ -139,3 +139,9 @@ let search =
 (* ------------------------------------------------------------------------- *)
 
 update_database();;
+
+(* This printf checks whether standard modules like Printf are still alive
+   after update_database.
+   See also: https://github.com/ocaml/ocaml/issues/12271 *)
+Printf.printf "update_database.ml loaded! # theorems: %d\n"
+   (List.length !theorems);;


### PR DESCRIPTION
This patch makes `load_camlp5_topfind.ml` not load compiler-libs.common. Without this patch, standard libraries like `Printf.printf` is unusable, raising this error message:
```
Error: The module Printf is an alias for module Stdlib__Printf, which is
missing
```

I think my fix was included in my previous pull request, but it was lost for some reason...

The reason why this line is necessary is as follows. OCaml 4.14 REPL has its compiler-libs.common expunged by default, but update_database_4.14.ml uses this library.
To resolve this problem,
(1) We need a toplevel whose compiler-libs.common isn't expunged. This is done by `ocamlmktop -o ocaml-hol` as the updated README says. (2) We need to tell `Topfind` that it must never load the library even if other libraries need it in their dependency because `ocaml-hol` already has that.

(2) is now resolved by this PR.

Patches for OCaml 4.14 are going a bit complicated, but yeah...

See also: https://github.com/ocaml/ocaml/issues/12271