### PR TITLE
Add `use_file_raise_failure` flag to control raising Failure

### DIFF
--- a/Help/use_file_raise_failure.hlp
+++ b/Help/use_file_raise_failure.hlp
@@ -1,0 +1,77 @@
+\DOC use_file_raise_failure
+
+\TYPE {use_file_raise_failure : bool ref}
+
+\SYNOPSIS
+Flag determining whether unsuccessful loading of an OCaml file must raise
+{Failure}.
+
+\DESCRIBE
+The reference variable {use_file_raise_failure} is used by the function
+{use_file} to determine whether an unsuccessful loading of a source file must
+raise {Failure} or simply print an error message on the screen.
+The default value is {false}.
+The behavior of {loads} and {loadt} are also affected by this flag because they
+internally invoke {use_file}.
+
+If this flag is set to {true}, recursive loading will immediately fail after any
+unsuccessful loading of a source file.
+This is helpful for pinpointing the failing location from loading multiple source
+files.
+On the other hand, this will cause Toplevel forget all OCaml bindings
+(`{let .. = ..;;}') that have been made during the load before the erroneous point,
+leading to a state whose OCaml definitions and constant definitions in HOL Light
+are inconsistent.
+
+If this flag is set to {false}, unsuccessful loading will simply print a error
+message and continue to the next statement.
+
+\FAILURE
+Not applicable.
+
+\EXAMPLE
+Consider {a.ml} that has the following text:
+{
+   loadt "b.ml";;
+   print_endline "b.ml loaded";;
+}
+\noindent and {b.ml}:
+{
+   undefined_var := 3;; (* Raises a failure *)
+}
+
+If {use_file_raise_failure} is set to {false} (which is default), the message
+in {a.ml} is printed even if {b.ml} fails.
+{
+   # loadt "a.ml";;
+   File "/home/ubuntu/hol-light-aqjune/b.ml", line 1, characters 0-13:
+                              1 | undefined_var := 3;; (* Raises a failure *)
+                                  ^^^^^^^^^^^^^
+                              Error: Unbound value undefined_var
+   Error in included file /home/ubuntu/hol-light-aqjune/b.ml
+   - : unit = ()
+   b.ml loaded
+   - : unit = ()
+   val it : unit = ()
+}
+However, if it is set to {true}, the message is not printed because loading
+{a.ml} also fails immediately after loading {b.ml}.
+Also, the stack trace is printed because the failure reaches to the top level.
+{
+   # use_file_raise_failure := true;;
+   val it : unit = ()
+   # loadt "a.ml";;
+   File "/home/ubuntu/hol-light-aqjune/b.ml", line 1, characters 0-13:
+   1 | undefined_var := 3;; (* Raises a failure *)
+       ^^^^^^^^^^^^^
+   Error: Unbound value undefined_var
+   Exception:
+   Failure "Error in included file /home/ubuntu/hol-light-aqjune/b.ml".
+   Exception:
+   Failure "Error in included file /home/ubuntu/hol-light-aqjune/a.ml".
+}
+
+\SEEALSO
+use_file, loads, loadt.
+
+\ENDDOC

--- a/hol.ml
+++ b/hol.ml
@@ -30,9 +30,20 @@ let temp_path = ref "/tmp";;
 (* $ character at the start of a directory.                                  *)
 (* ------------------------------------------------------------------------- *)
 
+(* A flag that sets whether use_file must raise Failure if loading the file  *)
+(* did not succeed. If set to true, this helps (nested) loading of files fail*)
+(* early. However, propagation of the failure will cause Toplevel to forget  *)
+(* bindings ('let .. = ..;;') that have been made before the erroneous       *)
+(* statement in the file. This leads to an inconsistent state between        *)
+(* variable and defined constants in HOL Light.                              *)
+let use_file_raise_failure = ref false;;
+
 let use_file s =
   if Toploop.use_file Format.std_formatter s then ()
-  else failwith("Error in included file "^s);;
+  else if !use_file_raise_failure
+  then failwith("Error in included file "^s)
+  else (Format.print_string("Error in included file "^s);
+        Format.print_newline());;
 
 let hol_expand_directory s =
   if s = "$" || s = "$/" then !hol_dir


### PR DESCRIPTION
This patch adds a flag that sets whether use_file must raise Failure if loading the file did not succeed. If set to true, this helps (nested) loading of files fail early. However, propagation of the failure will cause Toplevel to forget bindings ('let .. = ..;;') that have been made before the erroneous statement in the file. This leads to an inconsistent state between variable and defined constants in HOL Light.