### PR TITLE
Add `print_goal_hyp_max_boxes` to omit printing long hypotheses in goal

### DIFF
--- a/Help/print_all_thm.hlp
+++ b/Help/print_all_thm.hlp
@@ -26,7 +26,8 @@ Not applicable.
 }
 
 \SEEALSO
-pp_print_term, prebroken_binops, print_unambiguous_comprehensions,
-reverse_interface_mapping, typify_universal_set, unspaced_binops.
+pp_print_term, prebroken_binops, print_goal_hyp_max_boxes,
+print_unambiguous_comprehensions, reverse_interface_mapping,
+typify_universal_set, unspaced_binops.
 
 \ENDDOC

--- a/Help/print_goal_hyp_max_boxes.hlp
+++ b/Help/print_goal_hyp_max_boxes.hlp
@@ -1,0 +1,62 @@
+\DOC print_goal_hyp_max_boxes
+
+\TYPE {print_goal_hyp_max_boxes : int option ref}
+
+\SYNOPSIS
+Flag determining the maximum number of boxes used to pretty-print each hypothesis
+of a goal.
+
+\DESCRIBE
+The reference variable {print_goal_hyp_max_boxes} is a parameter controlling
+the maximum number of boxes used to pretty-print each hypothesis of a goal.
+This reference variable is used by {pp_print_goal}.
+A box is a logical unit for pretty-printing an object and it is used by OCaml's
+{Format} module.
+When it is set to {Some k}, {k} is used as the maximum number of boxes and
+terms in a hypothesis that need more than {k} boxes are abbreviated by a
+dot ({.}).
+When it is set to {None}, the maximum number of boxes configured in OCaml's
+default formatter is used.
+
+\FAILURE
+Not applicable.
+
+\EXAMPLE
+{
+   # g `1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 10
+        ==> 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`;;
+   val it : goalstack = 1 subgoal (1 total)
+
+   `1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 10
+   ==> 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`
+
+   # e(STRIP_TAC);;
+   val it : goalstack = 1 subgoal (1 total)
+
+   0 [`1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 10`]
+
+   `2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`
+
+   # print_goal_hyp_max_boxes := Some 5;;
+   val it : unit = ()
+   # p();;
+   val it : goalstack = 1 subgoal (1 total)
+
+   0 [`. = 10`]
+
+   `2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`
+
+   # print_goal_hyp_max_boxes := None;;
+   val it : unit = ()
+   # p();;
+   val it : goalstack = 1 subgoal (1 total)
+
+   0 [`1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 10`]
+
+   `2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`
+}
+
+\SEEALSO
+pp_print_goal, print_all_thm.
+
+\ENDDOC

--- a/tactics.ml
+++ b/tactics.ml
@@ -747,6 +747,10 @@ let ANTS_TAC =
 (* A printer for goals etc.                                                  *)
 (* ------------------------------------------------------------------------- *)
 
+(* A parameter to prettyprinter's max boxes for printing hypotheses.         *)
+(* Set to None if the formatter's default max boxes value is to be used.     *)
+let print_goal_hyp_max_boxes = ref None;;
+
 let (pp_print_goal:Format.formatter->goal->unit) =
   let string_of_int3 n =
     if n < 10 then "  "^string_of_int n
@@ -757,7 +761,12 @@ let (pp_print_goal:Format.formatter->goal->unit) =
     Format.pp_print_string fmt (string_of_int3 n);
     Format.pp_print_string fmt " [";
     pp_open_hvbox fmt 0;
+    let old_max_boxes = pp_get_max_boxes fmt () in
+    (match !print_goal_hyp_max_boxes with
+     | None -> ()
+     | Some hb -> pp_set_max_boxes fmt hb);
     pp_print_qterm fmt (concl th);
+    pp_set_max_boxes fmt old_max_boxes;
     pp_close_box fmt ();
     Format.pp_print_string fmt "]";
     (if not (s = "") then (Format.pp_print_string fmt (" ("^s^")")) else ());


### PR DESCRIPTION
This commit adds a `print_goal_hyp_max_boxes` variable that can be used to omit printing too long hypotheses in a goal.

It is a reference to `int option`. If it is `Some k`, `k` is given to the max boxes option of formatter for hypotheses. If it is `None`, nothing is set.

```
# g `1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 10 ==> 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`;;
val it : goalstack = 1 subgoal (1 total)

`1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 10
 ==> 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`

# e(STRIP_TAC);;
val it : goalstack = 1 subgoal (1 total)

  0 [`1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 10`]

`2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`

# print_goal_hyp_max_boxes := Some 10;;
val it : unit = ()
# p();;
val it : goalstack = 1 subgoal (1 total)

  0 [`1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 10`]

`2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`

# print_goal_hyp_max_boxes := Some 5;;
val it : unit = ()
# p();;
val it : goalstack = 1 subgoal (1 total)

  0 [`. = 10`]

`2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`

# print_goal_hyp_max_boxes := None;;
val it : unit = ()
# p();;
val it : goalstack = 1 subgoal (1 total)

  0 [`1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 = 10`]

`2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 20`
```