### PR TITLE
Print terms that invented types when `type_invention_error` is set

### DIFF
--- a/Help/type_invention_error.hlp
+++ b/Help/type_invention_error.hlp
@@ -31,7 +31,8 @@ fails with an error message:
   # type_invention_error := true;;
   val it : unit = ()
   # let tm = `x = x`;;
-  Exception: Failure "typechecking error (cannot infer type of variables)".
+  Exception:
+  Failure "typechecking error (cannot infer type of variables): =, x".
 }
 \noindent You can avoid the error by explicitly giving appropriate types or
 type variables yourself:


### PR DESCRIPTION
When `type_invention_error` flag is set, this patch prints the terms that invented types. This is helpful for debugging when every term is supposed to be fully typed but it actually isn't.

```
 # type_invention_error := true;;
 val it : unit = ()
 # let tm = `x = x`;;
 Exception:
 Failure "typechecking error (cannot infer type of variables): =, x".
 #
```