### PR TITLE
Add NAME_ASSUMS_TAC and PRINT_GOAL_TAC, improve error messages of a few decision procedures

### DIFF
--- a/Help/LABEL_TAC.hlp
+++ b/Help/LABEL_TAC.hlp
@@ -87,6 +87,6 @@ if {asm} is large, and using its number in the assumption list can make proofs
 very brittle under later changes.
 
 \SEEALSO
-ASSUME_TAC, DESTRUCT_TAC, HYP, INTRO_TAC, REMOVE_THEN, USE_THEN.
+ASSUME_TAC, DESTRUCT_TAC, NAME_ASSUMS_TAC, HYP, INTRO_TAC, REMOVE_THEN, USE_THEN.
 
 \ENDDOC

--- a/Help/NAME_ASSUMS_TAC.hlp
+++ b/Help/NAME_ASSUMS_TAC.hlp
@@ -1,0 +1,59 @@
+\DOC NAME_ASSUMS_LIST
+
+\TYPE {NAME_ASSUMS_LIST : tactic}
+
+\SYNOPSIS
+Label unnamed assumptions.
+
+\KEYWORDS
+assumption.
+
+\DESCRIBE
+{NAME_ASSUMS_LIST} labels unnamed assumptions with "H0", "H1", ....
+It skips named assumptions.
+
+\FAILURE
+Never fails.
+
+\EXAMPLE
+{
+	# g `!(a: A) b c d. a = b ==> b = c ==> c = d ==> a = d`;;
+	val it : goalstack = 1 subgoal (1 total)
+
+	`!a b c d. a = b ==> b = c ==> c = d ==> a = d`
+
+	# e(REPEAT GEN_TAC);;
+	val it : goalstack = 1 subgoal (1 total)
+
+	`a = b ==> b = c ==> c = d ==> a = d`
+
+	# e(DISCH_THEN (LABEL_TAC "Hnamed"));;
+	val it : goalstack = 1 subgoal (1 total)
+
+		0 [`a = b`] (Hnamed)
+
+	`b = c ==> c = d ==> a = d`
+
+	# e(REPEAT STRIP_TAC);;
+	val it : goalstack = 1 subgoal (1 total)
+
+		0 [`a = b`] (Hnamed)
+		1 [`b = c`]
+		2 [`c = d`]
+
+	`a = d`
+
+	# e(NAME_ASSUMS_TAC);;
+	val it : goalstack = 1 subgoal (1 total)
+
+		0 [`a = b`] (Hnamed)
+		1 [`b = c`] (H1)
+		2 [`c = d`] (H0)
+
+	`a = d`
+}
+
+\SEEALSO
+HYP, LABEL_TAC, REMOVE_THEN, USE_THEN.
+
+\ENDDOC

--- a/Help/PRINT_GOAL_TAC.hlp
+++ b/Help/PRINT_GOAL_TAC.hlp
@@ -1,0 +1,18 @@
+\DOC PRINT_GOAL_TAC
+
+\TYPE {PRINT_GOAL_TAC : tactic}
+
+\SYNOPSIS
+Prints the goal to standard output.
+
+\DESCRIBE
+Given any goal {A ?- p}, the tactic {PRINT_GOAL_TAC} prints the goal
+to standard output.
+
+\FAILURE
+Never fails.
+
+\SEEALSO
+print_goal, print_goalstack, print_term
+
+\ENDDOC

--- a/Help/print_goal.hlp
+++ b/Help/print_goal.hlp
@@ -6,7 +6,7 @@
 Print a goal.
 
 \DESCRIBE
-{print_goalstack g} prints the goal {g} to standard output, with no following
+{print_goal g} prints the goal {g} to standard output, with no following
 newline.
 
 \FAILURE
@@ -17,6 +17,6 @@ This is invoked automatically when something of type {goal} is produced at
 the top level, so manual invocation is not normally needed.
 
 \SEEALSO
-print_goalstack, print_term.
+print_goalstack, print_term, PRINT_GOAL_TAC.
 
 \ENDDOC

--- a/Help/print_goalstack.hlp
+++ b/Help/print_goalstack.hlp
@@ -17,6 +17,6 @@ This is invoked automatically when something of type {goalstack} is produced at
 the top level, so manual invocation is not normally needed.
 
 \SEEALSO
-print_goal, print_term.
+print_goal, print_term, PRINT_GOAL_TAC.
 
 \ENDDOC

--- a/Library/words.ml
+++ b/Library/words.ml
@@ -3377,9 +3377,12 @@ let WORD_RULE =
   let wordprover tm =
     try NUMBER_RULE tm with Failure _ -> prove(tm,WORD_UNBLAST_TAC) in
   fun tm ->
-    let avs,bod = strip_forall tm in
-    let th = ONCE_DEPTH_CONV WORD_VAL_CONG_CONV bod in
-    GENL avs (EQT_ELIM(TRANS th (EQT_INTRO(wordprover (rand(concl th))))));;
+    try
+      let avs,bod = strip_forall tm in
+      let th = ONCE_DEPTH_CONV WORD_VAL_CONG_CONV bod in
+      GENL avs (EQT_ELIM(TRANS th (EQT_INTRO(wordprover (rand(concl th))))))
+    with Failure m ->
+      failwith ("WORD_RULE `" ^ (string_of_term tm) ^ "`: " ^ m);;
 
 (* ------------------------------------------------------------------------- *)
 (* A somewhat complementary purely bitwise decision procedure.               *)
@@ -3409,7 +3412,13 @@ let WORD_BITWISE_TAC =
   TRY(GEN_TAC THEN DISCH_TAC) THEN ASM_REWRITE_TAC[] THEN
   CONV_TAC TAUT;;
 
-let WORD_BITWISE_RULE tm = prove(tm,WORD_BITWISE_TAC);;
+let WORD_BITWISE_RULE tm =
+  try 
+    prove(tm,WORD_BITWISE_TAC)
+  with Failure m ->
+    failwith ("WORD_BITWISE_RULE `" ^ (string_of_term tm) ^ "`: " ^ m);;
+
+let WORD_BITWISE_TAC = CONV_TAC WORD_BITWISE_RULE;;
 
 (* ------------------------------------------------------------------------- *)
 (* Slightly ad hoc but useful reduction to linear arithmetic.                *)
@@ -3439,7 +3448,13 @@ let WORD_ARITH_TAC =
   W(MAP_EVERY (MP_TAC o C ISPEC INT_VAL_BOUND) o find_terms wordy o snd) THEN
   REWRITE_TAC[CONJUNCT2 TWICE_MSB] THEN INT_ARITH_TAC;;
 
-let WORD_ARITH tm = prove(tm,WORD_ARITH_TAC);;
+let WORD_ARITH tm =
+  try
+    prove(tm,WORD_ARITH_TAC)
+  with Failure m ->
+    failwith ("WORD_ARITH `" ^ (string_of_term tm) ^ "`: " ^ m);;
+
+let WORD_ARITH_TAC = CONV_TAC WORD_ARITH;;
 
 (* ------------------------------------------------------------------------- *)
 (* Expand "val x" or "val x DIV 2 EXP k" or "val x MOD 2 EXP k"              *)
@@ -6317,8 +6332,11 @@ let WORD_BLAST =
     CONV_TAC conv THEN
     (INT_ARITH_TAC ORELSE CONV_TAC INT_RING) in
   fun tm ->
-    prove(tm,REPEAT(GEN_TAC ORELSE CONJ_TAC) THEN
-             (tac_word ORELSE tac_num));;
+    try
+      prove(tm,REPEAT(GEN_TAC ORELSE CONJ_TAC) THEN
+              (tac_word ORELSE tac_num))
+    with Failure m ->
+      failwith ("WORD_BLAST `" ^ (string_of_term tm) ^ "`: " ^ m);;
 
 (* ------------------------------------------------------------------------- *)
 (* Subadditivity (and a bit more) of popcount.                               *)

--- a/calc_rat.ml
+++ b/calc_rat.ml
@@ -529,7 +529,11 @@ let GEN_REAL_ARITH PROVER =
 let REAL_ARITH =
   let init = GEN_REWRITE_CONV ONCE_DEPTH_CONV [DECIMAL]
   and pure = GEN_REAL_ARITH REAL_LINEAR_PROVER in
-  fun tm -> let th = init tm in EQ_MP (SYM th) (pure(rand(concl th)));;
+  fun tm ->
+    try
+      let th = init tm in EQ_MP (SYM th) (pure(rand(concl th)))
+    with Failure m ->
+      failwith ("REAL_ARITH `" ^ (string_of_term tm) ^ "`: " ^ m);;
 
 let REAL_ARITH_TAC = CONV_TAC REAL_ARITH;;
 

--- a/class.ml
+++ b/class.ml
@@ -376,7 +376,10 @@ let TAUT =
      W((fun t1 t2 -> t1 THEN t2) (REWRITE_TAC[]) o BOOL_CASES_TAC o
        hd o sort free_in o find_terms ok o snd)) (asl,w) in
   let TAUT_TAC = REPEAT(GEN_TAC ORELSE CONJ_TAC) THEN REPEAT RTAUT_TAC in
-  fun tm -> prove(tm,TAUT_TAC);;
+  fun tm ->
+    try prove(tm,TAUT_TAC)
+    with Failure _ ->
+      failwith ("TAUT `" ^ (string_of_term tm) ^ "`: cannot solve");;
 
 (* ------------------------------------------------------------------------- *)
 (* Throw monotonicity in.                                                    *)

--- a/int.ml
+++ b/int.ml
@@ -2150,17 +2150,20 @@ let ARITH_RULE =
       Comb(Const("int_of_num",_),n) when not(is_numeral n) -> true
     | _ -> false in
   fun tm ->
-    let th1 = init_conv tm in
-    let tm1 = rand(concl th1) in
-    let avs,bod = strip_forall tm1 in
-    let nim = setify(find_terms is_numimage bod) in
-    let gvs = map (genvar o type_of) nim in
-    let pths = map (fun v -> SPEC (rand v) INT_POS) nim in
-    let ibod = itlist (curry mk_imp o concl) pths bod in
-    let gbod = subst (zip gvs nim) ibod in
-    let th2 = INST (zip nim gvs) (INT_ARITH gbod) in
-    let th3 = GENL avs (rev_itlist (C MP) pths th2) in
-    EQ_MP (SYM th1) th3;;
+    try
+      let th1 = init_conv tm in
+      let tm1 = rand(concl th1) in
+      let avs,bod = strip_forall tm1 in
+      let nim = setify(find_terms is_numimage bod) in
+      let gvs = map (genvar o type_of) nim in
+      let pths = map (fun v -> SPEC (rand v) INT_POS) nim in
+      let ibod = itlist (curry mk_imp o concl) pths bod in
+      let gbod = subst (zip gvs nim) ibod in
+      let th2 = INST (zip nim gvs) (INT_ARITH gbod) in
+      let th3 = GENL avs (rev_itlist (C MP) pths th2) in
+      EQ_MP (SYM th1) th3
+    with Failure msg ->
+      failwith ("ARITH_RULE `" ^ (string_of_term tm) ^ "`: " ^ msg);;
 
 let ARITH_TAC = CONV_TAC(EQT_INTRO o ARITH_RULE);;
 
@@ -2236,10 +2239,13 @@ let INT_ARITH =
   and not_tm = `(~)` in
   let pth = TAUT(mk_eq(mk_neg(mk_neg p_tm),p_tm)) in
   fun tm ->
-    let th0 = INST [tm,p_tm] pth
-    and th1 = init_CONV (mk_neg tm) in
-    let th2 = REAL_ARITH(mk_neg(rand(concl th1))) in
-    EQ_MP th0 (EQ_MP (AP_TERM not_tm (SYM th1)) th2);;
+    try
+      let th0 = INST [tm,p_tm] pth
+      and th1 = init_CONV (mk_neg tm) in
+      let th2 = REAL_ARITH(mk_neg(rand(concl th1))) in
+      EQ_MP th0 (EQ_MP (AP_TERM not_tm (SYM th1)) th2)
+    with Failure m ->
+      failwith ("INT_ARITH `" ^ (string_of_term tm) ^ "`: " ^ m);;
 
 let INT_ARITH_TAC = CONV_TAC(EQT_INTRO o INT_ARITH);;
 

--- a/tactics.ml
+++ b/tactics.ml
@@ -295,6 +295,20 @@ let (REMOVE_THEN:string->thm_tactic->tactic) =
     let asl' = asl1 @ tl asl2 in
     ttac th (asl',w);;
 
+let NAME_ASSUMS_TAC: tactic =
+  fun (asl,g) ->
+    let idx: int ref = ref 0 in
+    let has (name:string) = exists (fun (name',_) -> name = name') asl in
+    let rec next_hyp_name (): string =
+      let n = "H" ^ (string_of_int !idx) in
+      idx := !idx + 1;
+      if has n then next_hyp_name ()
+      else n in
+    let asl = map
+      (fun (name,a) -> if name = "" then (next_hyp_name(),a) else (name,a))
+      asl in
+    ALL_TAC (asl,g);;
+
 (* ------------------------------------------------------------------------- *)
 (* General tools to augment a required set of theorems with assumptions.     *)
 (* Here ASM uses all current hypotheses of the goal, while HYP uses only     *)
@@ -805,6 +819,7 @@ let (pp_print_goalstack:Format.formatter->goalstack->unit) =
 
 let print_goal = pp_print_goal Format.std_formatter;;
 let print_goalstack = pp_print_goalstack Format.std_formatter;;
+let PRINT_GOAL_TAC: tactic = fun gl -> print_goal gl; ALL_TAC gl;;
 
 (* ------------------------------------------------------------------------- *)
 (* Convert a tactic into a refinement on head subgoal in current state.      *)


### PR DESCRIPTION
This patch adds two simple tactics and improves error messages of a few decision procedures.

The added tactics are PRINT_GOAL_TAC and NAME_ASSUMS_TAC. PRINT_GOAL_TAC simply prints the current goal. This is useful for debugging failures from a complicated tactic. NAME_ASSUMS_TAC labels all unnamed assumptions in the goal. This is useful when it is hard to pick an assumption using ASSUME or FIRST_ASSUM.

The improved error message now contains the goal term that the decision procedure tried to solve but failed. Updated conversions and tactics are WORD_ARITH, WORD_ARITH_TAC, WORD_BLAST, WORD_RULE, WORD_BITWISE_RULE, ARITH_RULE, ARITH_TAC, INT_ARITH, INT_ARITH_TAC, REAL_ARITH, REAL_ARITH_TAC and TAUT.

```
> ARITH_RULE `1 = 0`;;
Exception: Failure "ARITH_RULE `1 = 0`: linear_ineqs: no contradiction".

> prove(`1=2`, ARITH_TAC);;
Exception: Failure "ARITH_RULE `1 = 2`: linear_ineqs: no contradiction".
```