### PR TITLE
Print "'name' is already defined" message

### DIFF
--- a/define.ml
+++ b/define.ml
@@ -982,9 +982,13 @@ let define =
         else failwith ""
     with Failure _ ->
       let f,th = close_definition_clauses tm in
-      let etm = mk_exists(f,hd(hyp th)) in
-      let th1 = prove_general_recursive_function_exists etm in
-      let th2 = new_specification[fst(dest_var f)] th1 in
-      let g = mk_mconst(dest_var f) in
-      let th3 = PROVE_HYP th2 (INST [g,f] th) in
-      the_definitions := th3::(!the_definitions); th3;;
+      if not (is_var f) then
+        (* If f is not Var, mk_exists will fail. *)
+        failwith ("define: '" ^ (string_of_term f) ^ "' is already defined")
+      else
+        let etm = mk_exists(f,hd(hyp th)) in
+        let th1 = prove_general_recursive_function_exists etm in
+        let th2 = new_specification[fst(dest_var f)] th1 in
+        let g = mk_mconst(dest_var f) in
+        let th3 = PROVE_HYP th2 (INST [g,f] th) in
+        the_definitions := th3::(!the_definitions); th3;;

--- a/fusion.ml
+++ b/fusion.ml
@@ -597,6 +597,8 @@ module Hol : Hol_kernel = struct
         else let c = new_constant(cname,ty); Const(cname,ty) in
              let dth = Sequent([],safe_mk_eq c r) in
              the_definitions := dth::(!the_definitions); dth
+    | Comb(Comb(Const("=",_),Const(cname,ty)),r) ->
+      failwith ("new_basic_definition: '" ^ cname ^ "' is already defined")
     | _ -> failwith "new_basic_definition"
 
 (* ------------------------------------------------------------------------- *)


### PR DESCRIPTION
This is a small patch that updates `new_basic_definition` and `define` to print "'name' is already defined" error message if the constant already exists. This also makes `new_definition` print the message because it internally calls `new_basic_definition`.

```
# new_basic_definition `x=10`;;
val it : thm = |- x = 10
# new_basic_definition `x=20`;;
Exception: Failure "new_basic_definition: 'x' is already defined".
# new_definition `x=20`;;
Exception: Failure "new_basic_definition: 'x' is already defined".
# define `x=30`;;
Exception: Failure "define: 'x' is already defined".
```

Three more definition functions (`new_recursive_definition`, `new_inductive_definition` and `new_specification`) are not updated in this patch. I avoided touching them because their implementations look complicated to me. :/