### PR TITLE
Fix include Bignum failure when hol.sh is loaded outside hol-light

### DIFF
--- a/hol_4.14.sh
+++ b/hol_4.14.sh
@@ -15,4 +15,4 @@ if [ -d "${HOLLIGHT_DIR}/_opam" ]; then
   eval $(opam env --switch "${HOLLIGHT_DIR}/" --set-switch)
 fi
 
-${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -init ${HOLLIGHT_DIR}/hol.ml
+${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -init ${HOLLIGHT_DIR}/hol.ml -I ${HOLLIGHT_DIR}

--- a/hol_4.sh
+++ b/hol_4.sh
@@ -15,4 +15,4 @@ if [ -d "${HOLLIGHT_DIR}/_opam" ]; then
   eval $(opam env --switch "${HOLLIGHT_DIR}/" --set-switch)
 fi
 
-${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -I `camlp5 -where` camlp5o.cma -init ${HOLLIGHT_DIR}/hol.ml -safe-string
+${LINE_EDITOR} ${HOLLIGHT_DIR}/ocaml-hol -I `camlp5 -where` camlp5o.cma -init ${HOLLIGHT_DIR}/hol.ml -safe-string -I ${HOLLIGHT_DIR}


### PR DESCRIPTION
This fixes a failure from `include Bignum` by adding a include directory to `ocaml-hol`.