### PR TITLE
Support compilation of HOL Light

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .vscode
 _opam
+*.cma
 *.cmi
 *.cmo
 *.o
@@ -9,3 +10,4 @@ pa_j.ml
 update_database.ml
 ocaml-hol
 hol.sh
+hol_lib_inlined.ml

--- a/README
+++ b/README
@@ -260,6 +260,32 @@ checkpointing programs.
 
         *       *       *       *       *       *       *       *
 
+                         COMPILING HOL LIGHT
+
+Running 'HOLLIGHT_USE_MODULE=1 make' will compile hol_lib.ml and generate
+hol_lib.cmo. This will also create hol.sh which will configure hol.ml to use
+the compiled hol_lib.cmo. Compiling HOL Light will only work on OCaml 4.14
+or above.
+
+To compile an OCaml file that opens Hol_lib, use the following command.
+
+    ocamlfind ocamlc -package zarith -linkpkg -pp \
+      "camlp5r pa_lexer.cmo pa_extend.cmo q_MLast.cmo -I . (HOL dir)pa_j.cmo" \
+      -I (HOL dir) (HOL dir)/bignum.cmo (HOL dir)/hol_loader.cmo \
+      (HOL dir)/hol_lib.cmo (input.ml) -o (output.ml)
+
+The load functions (loads/loadt/needs) are not available anymore in this
+approach. Please use 'ocaml inline_loads.ml <input.ml> <output.ml>' to inline
+their invocations.
+
+NOTE: Compiling HOL Light with 'HOLLIGHT_USE_MODULE=1' extends the trusted base
+of HOL Light to include the inliner script, inline_loads.ml. inline_loads.ml is
+an OCaml program that receives an HOL Light proof and replaces the
+loads/loadt/needs function invocations with their actual contents. Please turn
+this flag on only if having this additional trusted base is considered okay.
+
+        *       *       *       *       *       *       *       *
+
 [*] HOL Light uses the OCaml 'num' library for multiple-precision
 rationals. On many platforms, including Linux and native Windows, this
 will be loaded automatically by the HOL root file 'hol.ml'. However,

--- a/hol.ml
+++ b/hol.ml
@@ -21,7 +21,12 @@ let hol_version = "2.20++";;
 
 let temp_path = ref "/tmp";;
 
-#use "hol_loader.ml";;
+(* ------------------------------------------------------------------------- *)
+(* Load the load/need functions.                                             *)
+(* ------------------------------------------------------------------------- *)
+
+#load "hol_loader.cmo";;
+include Hol_loader;;
 
 file_loader := fun s -> Toploop.use_file Format.std_formatter s;;
 (* Hide the definition of file_loader of hol_loader.ml.                      *)
@@ -50,7 +55,11 @@ Topdirs.dir_load Format.std_formatter (Filename.concat (!hol_dir) "pa_j.cmo");;
 (* Load the core files.                                                      *)
 (* ------------------------------------------------------------------------- *)
 
-loads "hol_lib.ml";;
+let use_module =
+  try Sys.getenv "HOLLIGHT_USE_MODULE" = "1" with Not_found -> false;;
+if use_module
+then loads "hol_lib_use_module.ml"
+else loads "hol_lib.ml";;
 
 (* ------------------------------------------------------------------------- *)
 (* Install printers.                                                         *)

--- a/hol_4.14.sh
+++ b/hol_4.14.sh
@@ -9,6 +9,7 @@ fi
 
 # Makefile will replace __DIR__ with the path
 export HOLLIGHT_DIR=__DIR__
+export HOLLIGHT_USE_MODULE=__USE_MODULE__
 
 # If a local OPAM is installed, use it
 if [ -d "${HOLLIGHT_DIR}/_opam" ]; then

--- a/hol_4.sh
+++ b/hol_4.sh
@@ -9,6 +9,7 @@ fi
 
 # Makefile will replace __DIR__ with the path
 export HOLLIGHT_DIR=__DIR__
+export HOLLIGHT_USE_MODULE=__USE_MODULE__
 
 # If a local OPAM is installed, use it
 if [ -d "${HOLLIGHT_DIR}/_opam" ]; then

--- a/hol_lib.ml
+++ b/hol_lib.ml
@@ -11,6 +11,7 @@
 (* ========================================================================= *)
 
 include Bignum;;
+open Hol_loader;;
 
 (* ------------------------------------------------------------------------- *)
 (* Bind these to names that are independent of OCaml versions before they    *)

--- a/hol_lib_use_module.ml
+++ b/hol_lib_use_module.ml
@@ -1,0 +1,15 @@
+(* ========================================================================= *)
+(*                               HOL LIGHT                                   *)
+(*                                                                           *)
+(*              Modern OCaml version of the HOL theorem prover               *)
+(*                                                                           *)
+(*                            John Harrison                                  *)
+(*                                                                           *)
+(*            (c) Copyright, University of Cambridge 1998                    *)
+(*              (c) Copyright, John Harrison 1998-2024                       *)
+(*              (c) Copyright, Juneyoung Lee 2024                            *)
+(* ========================================================================= *)
+
+Topdirs.dir_load Format.std_formatter
+  (Filename.concat (!hol_dir) "hol_lib.cmo");;
+include Hol_lib;;

--- a/inline_load.ml
+++ b/inline_load.ml
@@ -1,0 +1,82 @@
+(* ========================================================================= *)
+(*                               HOL LIGHT                                   *)
+(*                                                                           *)
+(*              Modern OCaml version of the HOL theorem prover               *)
+(*                                                                           *)
+(*                            John Harrison                                  *)
+(*                                                                           *)
+(*            (c) Copyright, University of Cambridge 1998                    *)
+(*              (c) Copyright, John Harrison 1998-2024                       *)
+(*              (c) Copyright, Juneyoung Lee 2024                            *)
+(* ========================================================================= *)
+
+if Array.length Sys.argv <> 3 then
+  let _ = Printf.eprintf "inline_load.ml <input.ml> <output.ml>\n" in
+  exit 1;;
+
+let filename = Sys.argv.(1);;
+let fout = open_out (Sys.argv.(2));;
+
+#use "hol_loader.ml";;
+
+let parse_load_statement fnname stmt: (string * string) option =
+  let stmt = String.trim stmt in
+  if not (String.starts_with ~prefix:fnname stmt) then None else
+  let n = String.length fnname in
+  let stmt = String.trim (String.sub stmt n (String.length stmt - n)) in
+  if not (stmt.[0] = '"') then None else
+  let stmt = String.sub stmt 1 (String.length stmt - 1) in
+  let idx = String.index stmt '"' in
+  if idx = -1 then None else
+  let path = String.sub stmt 0 idx in
+  let stmt = String.sub stmt (idx + 1) (String.length stmt - idx - 1) in
+  let stmt = String.trim stmt in
+  if not (String.starts_with ~prefix:";;" stmt) then None else
+  let stmt = String.sub stmt 2 (String.length stmt - 2) in
+  Some (path,stmt);;
+
+
+let strings_of_file filename =
+  let fd =
+    try open_in filename
+    with Sys_error _ -> failwith("strings_of_file: can't open "^filename) in
+  let rec suck_lines acc =
+    let l = try [input_line fd] with End_of_file -> [] in
+     if l = [] then List.rev acc else suck_lines(List.hd l::acc) in
+  let data = suck_lines [] in
+  (close_in fd; data);;
+
+file_loader := fun filename ->
+  let open Printf in
+  fprintf fout "(* %s *)\n" filename;
+  let lines = strings_of_file filename in
+  List.iter
+    (fun line ->
+      match parse_load_statement "loadt" line with
+      | Some (path,line') -> loadt path; fprintf fout "%s\n" line' | None ->
+      (match parse_load_statement "loads" line with
+      | Some (path,line') -> loads path; fprintf fout "%s\n" line' | None ->
+      (match parse_load_statement "needs" line with
+      | Some (path,line') -> needs path; fprintf fout "%s\n" line'
+      | None -> fprintf fout "%s\n" line (* no linebreak needed! *))))
+    lines;
+  (* add digest *)
+  let digest_str = Digest.file filename in
+  let digest = Bytes.of_string digest_str in
+  let the_str = ref "" in
+  Bytes.iter (fun c ->
+      let i = Char.code c in
+      if !the_str = ""
+      then the_str := string_of_int i
+      else the_str := !the_str ^ "; " ^ (string_of_int i))
+    digest;
+  fprintf fout "(* update digest *)\n";
+  fprintf fout "loaded_files := \n";
+  fprintf fout "  let digest_bytes = [|%s|] in\n" !the_str;
+  fprintf fout "  let digest = Bytes.init (Array.length digest_bytes) (fun i -> Char.chr digest_bytes.(i)) in\n";
+  fprintf fout "  (\"%s\", Bytes.to_string digest)::!loaded_files;;\n\n" (Filename.basename filename);
+  true;;
+
+loadt filename;;
+
+close_out fout;;


### PR DESCRIPTION
This patch supports compilation of HOL Light.
If the `HOLLIGHT_USE_MODULE` environment variable is set to 1, Makefile builds `hol_lib.cmo` and makes `hol.sh` to use it. It first generates `hol_lib_inlined.ml` which is the output of the new `inline_load.ml` script which inlines all `loads`/`loadt`/`needs` invocations of the input file. Then, it compiles the inlined file with ocmal compiler.

Compiling HOL Light with 'HOLLIGHT_USE_MODULE=1' extends the trusted base of HOL Light to include the inliner script, inline_loads.ml. inline_loads.ml is an OCaml program that receives an HOL Light proof and replaces the loads/loadt/needs function invocations with their actual contents. The README file newly explains that this flag should be turned of only if having this additional trusted base is considered okay.

This pull request passed holtest as well as s2n-bignum proof tests (OCaml 4.14 used, `HOLLIGHT_USE_MODULE` turned on).
The patch was written before my vacation; just opening this pull request now...