### PR TITLE
Enhance word automation procedures WORD_ARITH and BITBLAST_RULE

### DIFF
--- a/int.ml
+++ b/int.ml
@@ -2195,11 +2195,19 @@ let INT_ARITH =
     let DIVREM_ELIM_THM = prove
      (`P (m div n) (m rem n) <=>
        ?q r. (n = &0 /\ q = &0 /\ r = m \/
-              m = q * n + r /\ &0 <= r /\ r < abs n) /\
+              m = q * n + r /\
+              (&0 <= m /\ &0 <= n ==> &0 <= q) /\
+              &0 <= r /\ r + &1 <= abs n) /\
              P q r`,
-      ASM_CASES_TAC `n:int = &0` THEN
-      ASM_METIS_TAC[INT_DIVISION; INT_DIV_0; INT_REM_0; INT_LET_ANTISYM;
-                    INT_DIVMOD_UNIQ; INT_DIVISION_SIMP])
+      REWRITE_TAC[GSYM INT_LT_DISCRETE] THEN
+      ASM_CASES_TAC `n:int = &0` THEN ASM_REWRITE_TAC[] THENL
+       [ASM_REWRITE_TAC[INT_ABS_NUM; INT_LET_ANTISYM] THEN
+        REWRITE_TAC[UNWIND_THM2; GSYM CONJ_ASSOC; RIGHT_EXISTS_AND_THM] THEN
+        REWRITE_TAC[INT_DIV_0; INT_REM_0];
+        EQ_TAC THEN STRIP_TAC THENL
+         [MAP_EVERY EXISTS_TAC [`m div n`; `m rem n`] THEN
+          ASM_SIMP_TAC[INT_DIVISION; INT_LE_DIV];
+          ASM_METIS_TAC[INT_DIVMOD_UNIQ]]]) 
     and BETA2_CONV = RATOR_CONV BETA_CONV THENC BETA_CONV
     and div_tm = `(div):int->int->int`
     and rem_tm = `(rem):int->int->int`


### PR DESCRIPTION
This makes the word decision procedures WORD_ARITH/WORD_ARITH_TAC and BITBLAST_RULE more capable in several ways:

 * Both BITBLAST_RULE and WORD_ARITH make more systematic reduction of word ground expressions internally.

 * BITBLAST_RULE now transforms "val(x) MOD n" and "val(x) DIV n" where n is (or can be transformed into) a power of 2, into bitwise equivalents so that the core procedure can handle it.

 * WORD_ARITH also expands "val(word n)" into "n MOD ...." after all the casewise "linear" expansions have been tried, giving it some capacity to handle multiplication by constants.

 * The underlying integer arithmetic procedure INT_ARITH has been enhanced so that it is never worse to use it than the natural number version, because it will infer nonnegativity of quotients introduced by div/rem elimination where possible.

Here are some word examples that work now but didn't before:

 WORD_ARITH
   `!m n. m < 4096 /\ n <= 511
        ==> word_ule (word_add (word_mul (word n) (word 0x00001000)) (word m))
                     (word 0x0000000001FFFFFF:int64)`;;

  BITBLAST_RULE
    `word_and x (word 256):int64 = word 0 <=> val x MOD 512 < 256`;;