### PR TITLE
Add conversions of num/int/rat/real/word that evaluate expressions using Compute

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Run
         run: |
+          set -e
           cd hol-light
           eval $(opam env)
           make
@@ -58,6 +59,7 @@ jobs:
 
       - name: Run
         run: |
+          set -e
           cd hol-light
           make switch
           eval $(opam env)
@@ -69,6 +71,7 @@ jobs:
 
       - name: Run (HOLLIGHT_USE_MODULE=1)
         run: |
+          set -e
           cd hol-light
           eval $(opam env)
           make clean

--- a/Library/words.ml
+++ b/Library/words.ml
@@ -8101,77 +8101,92 @@ let WORD_JREM_CONV =
   RAND_CONV (LAND_CONV WORD_JDIV_CONV THENC WORD_MUL_CONV) THENC
   WORD_SUB_CONV;;
 
+let word_red_conv_list =
+ [`word(NUMERAL n):N word`,CHANGED_CONV WORD_WORD_CONV;
+  `word_saturate(NUMERAL n):N word`,WORD_SATURATE_CONV;
+  `iword i:N word`,WORD_IWORD_CONV;
+  `iword_saturate(n):N word`,IWORD_SATURATE_CONV;
+  `val(w:N word)`,WORD_VAL_CONV;
+  `ival(w:N word)`,WORD_IVAL_CONV;
+  `bit (NUMERAL k) (word(NUMERAL n):N word)`,WORD_BIT_CONV;
+  `word(NUMERAL m):N word = word(NUMERAL n)`,WORD_EQ_CONV;
+  `word_ult (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_ULT_CONV;
+  `word_ule (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_ULE_CONV;
+  `word_ugt (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UGT_CONV;
+  `word_uge (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UGE_CONV;
+  `word_ilt (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_ILT_CONV;
+  `word_ile (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_ILE_CONV;
+  `word_igt (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_IGT_CONV;
+  `word_ige (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_IGE_CONV;
+  `word_neg (word(NUMERAL n):N word)`,WORD_NEG_CONV;
+  `word_add (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_ADD_CONV;
+  `word_mul (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_MUL_CONV;
+  `word_sub (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_SUB_CONV;
+  `word_udiv (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UDIV_CONV;
+  `word_umod (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UMOD_CONV;
+  `word_umax (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UMAX_CONV;
+  `word_umin (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UMIN_CONV;
+  `word_imax (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_IMAX_CONV;
+  `word_imin (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_IMIN_CONV;
+  `word_shl (word(NUMERAL m):N word) (NUMERAL n)`,WORD_SHL_CONV;
+  `word_ushr (word(NUMERAL m):N word) (NUMERAL n)`,WORD_USHR_CONV;
+  `word_ishr (word(NUMERAL m):N word) (NUMERAL n)`,WORD_ISHR_CONV;
+  `word_not (word(NUMERAL n):N word)`,WORD_NOT_CONV;
+  `word_and (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_AND_CONV;
+  `word_or (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_OR_CONV;
+  `word_xor (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_XOR_CONV;
+  `word_rol (word(NUMERAL m):N word) (NUMERAL n)`,WORD_ROL_CONV;
+  `word_ror (word(NUMERAL m):N word) (NUMERAL n)`,WORD_ROR_CONV;
+  `word_zx (word(NUMERAL n):N word)`,WORD_ZX_CONV;
+  `word_sx (word(NUMERAL n):N word)`,WORD_SX_CONV;
+  `word_sxfrom (NUMERAL m) (word(NUMERAL n):N word)`,WORD_SXFROM_CONV;
+  `word_cand (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_CAND_CONV;
+  `word_cor (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_COR_CONV;
+  `word_join (word(NUMERAL m):M word) (word(NUMERAL n):N word)`,
+              WORD_JOIN_CONV;
+  `word_subword (word(NUMERAL m):M word) (NUMERAL p,NUMERAL q):N word`,
+              WORD_SUBWORD_CONV;
+  `word_insert (word(NUMERAL m):M word) (NUMERAL p,NUMERAL q)
+               (word(NUMERAL n):N word):P word`,
+              WORD_INSERT_CONV;
+  `word_duplicate (word(NUMERAL m):M word):N word`,WORD_DUPLICATE_CONV;
+  `bits_of_word (word(NUMERAL n):N word)`,WORD_BITS_OF_WORD_CONV;
+  `word_popcount (word(NUMERAL n):N word)`,WORD_POPCOUNT_CONV;
+  `word_evenparity (word(NUMERAL n):N word)`,WORD_EVENPARITY_CONV;
+  `word_oddparity (word(NUMERAL n):N word)`,WORD_ODDPARITY_CONV;
+  `word_ctz (word(NUMERAL n):N word)`,WORD_CTZ_CONV;
+  `word_clz (word(NUMERAL n):N word)`,WORD_CLZ_CONV;
+  `word_bytereverse (word(NUMERAL n):((((N)tybit0)tybit0)tybit0)word)`,
+              WORD_BYTEREVERSE_CONV;
+  `word_reversefields (NUMERAL b) (word(NUMERAL n):N word)`,
+              WORD_REVERSEFIELDS_CONV;
+  `word_jshl (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JSHL_CONV;
+  `word_jshr (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JSHR_CONV;
+  `word_jushr (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JUSHR_CONV;
+  `word_jrol (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JROL_CONV;
+  `word_jror (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JROR_CONV;
+  `word_jdiv (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JDIV_CONV;
+  `word_jrem (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JREM_CONV];;
+
 let WORD_RED_CONV =
-  let gconv_net = itlist (uncurry net_of_conv)
-   [`word(NUMERAL n):N word`,CHANGED_CONV WORD_WORD_CONV;
-    `word_saturate(NUMERAL n):N word`,WORD_SATURATE_CONV;
-    `iword i:N word`,WORD_IWORD_CONV;
-    `iword_saturate(n):N word`,IWORD_SATURATE_CONV;
-    `val(w:N word)`,WORD_VAL_CONV;
-    `ival(w:N word)`,WORD_IVAL_CONV;
-    `bit (NUMERAL k) (word(NUMERAL n):N word)`,WORD_BIT_CONV;
-    `word(NUMERAL m):N word = word(NUMERAL n)`,WORD_EQ_CONV;
-    `word_ult (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_ULT_CONV;
-    `word_ule (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_ULE_CONV;
-    `word_ugt (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UGT_CONV;
-    `word_uge (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UGE_CONV;
-    `word_ilt (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_ILT_CONV;
-    `word_ile (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_ILE_CONV;
-    `word_igt (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_IGT_CONV;
-    `word_ige (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_IGE_CONV;
-    `word_neg (word(NUMERAL n):N word)`,WORD_NEG_CONV;
-    `word_add (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_ADD_CONV;
-    `word_mul (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_MUL_CONV;
-    `word_sub (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_SUB_CONV;
-    `word_udiv (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UDIV_CONV;
-    `word_umod (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UMOD_CONV;
-    `word_umax (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UMAX_CONV;
-    `word_umin (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_UMIN_CONV;
-    `word_imax (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_IMAX_CONV;
-    `word_imin (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_IMIN_CONV;
-    `word_shl (word(NUMERAL m):N word) (NUMERAL n)`,WORD_SHL_CONV;
-    `word_ushr (word(NUMERAL m):N word) (NUMERAL n)`,WORD_USHR_CONV;
-    `word_ishr (word(NUMERAL m):N word) (NUMERAL n)`,WORD_ISHR_CONV;
-    `word_not (word(NUMERAL n):N word)`,WORD_NOT_CONV;
-    `word_and (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_AND_CONV;
-    `word_or (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_OR_CONV;
-    `word_xor (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_XOR_CONV;
-    `word_rol (word(NUMERAL m):N word) (NUMERAL n)`,WORD_ROL_CONV;
-    `word_ror (word(NUMERAL m):N word) (NUMERAL n)`,WORD_ROR_CONV;
-    `word_zx (word(NUMERAL n):N word)`,WORD_ZX_CONV;
-    `word_sx (word(NUMERAL n):N word)`,WORD_SX_CONV;
-    `word_sxfrom (NUMERAL m) (word(NUMERAL n):N word)`,WORD_SXFROM_CONV;
-    `word_cand (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_CAND_CONV;
-    `word_cor (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_COR_CONV;
-    `word_join (word(NUMERAL m):M word) (word(NUMERAL n):N word)`,
-                WORD_JOIN_CONV;
-    `word_subword (word(NUMERAL m):M word) (NUMERAL p,NUMERAL q):N word`,
-                WORD_SUBWORD_CONV;
-    `word_insert (word(NUMERAL m):M word) (NUMERAL p,NUMERAL q)
-                 (word(NUMERAL n):N word):P word`,
-                WORD_INSERT_CONV;
-    `word_duplicate (word(NUMERAL m):M word):N word`,WORD_DUPLICATE_CONV;
-    `bits_of_word (word(NUMERAL n):N word)`,WORD_BITS_OF_WORD_CONV;
-    `word_popcount (word(NUMERAL n):N word)`,WORD_POPCOUNT_CONV;
-    `word_evenparity (word(NUMERAL n):N word)`,WORD_EVENPARITY_CONV;
-    `word_oddparity (word(NUMERAL n):N word)`,WORD_ODDPARITY_CONV;
-    `word_ctz (word(NUMERAL n):N word)`,WORD_CTZ_CONV;
-    `word_clz (word(NUMERAL n):N word)`,WORD_CLZ_CONV;
-    `word_bytereverse (word(NUMERAL n):((((N)tybit0)tybit0)tybit0)word)`,
-                WORD_BYTEREVERSE_CONV;
-    `word_reversefields (NUMERAL b) (word(NUMERAL n):N word)`,
-                WORD_REVERSEFIELDS_CONV;
-    `word_jshl (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JSHL_CONV;
-    `word_jshr (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JSHR_CONV;
-    `word_jushr (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JUSHR_CONV;
-    `word_jrol (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JROL_CONV;
-    `word_jror (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JROR_CONV;
-    `word_jdiv (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JDIV_CONV;
-    `word_jrem (word(NUMERAL m):N word) (word(NUMERAL n))`,WORD_JREM_CONV]
-  (basic_net()) in
+  let gconv_net = itlist (uncurry net_of_conv) word_red_conv_list (basic_net()) in
   REWRITES_CONV gconv_net;;
 
-let WORD_REDUCE_CONV = DEPTH_CONV WORD_RED_CONV;;
+let WORD_REDUCE_CONV =
+  DEPTH_CONV WORD_RED_CONV;;
+
+let word_compute_add_convs =
+  let convlist = map (fun pat,the_conv ->
+    let c,args = strip_comb pat in (c,length args,the_conv))
+    word_red_conv_list in
+  fun (compset:Compute.compset) ->
+    itlist (fun newc () -> Compute.add_conv newc compset) convlist ();;
+
+let WORD_COMPUTE_CONV =
+  let cs = Compute.bool_compset () in
+  Compute.set_skip cs `COND: bool -> A -> A -> A` (Some 1);
+  word_compute_add_convs cs;
+  Compute.WEAK_CBV_CONV cs;;
 
 (* ------------------------------------------------------------------------- *)
 (* Alternative returning signed words.                                       *)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ HOLSRC=system.ml lib.ml fusion.ml basics.ml nets.ml preterm.ml          \
        parser.ml printer.ml equal.ml bool.ml drule.ml tactics.ml        \
        itab.ml simp.ml theorems.ml ind_defs.ml class.ml trivia.ml       \
        canon.ml meson.ml firstorder.ml metis.ml thecops.ml quot.ml      \
-       impconv.ml recursion.ml pair.ml                                  \
+       impconv.ml recursion.ml pair.ml compute.ml                       \
        nums.ml arith.ml wf.ml calc_num.ml normalizer.ml grobner.ml      \
        ind_types.ml lists.ml realax.ml calc_int.ml realarith.ml         \
        real.ml calc_rat.ml int.ml sets.ml iterate.ml cart.ml define.ml  \
@@ -135,7 +135,7 @@ hol_loader.cmo: hol_loader.ml ; \
 hol_loader.cmx: hol_loader.ml ; \
         ocamlopt -verbose -c hol_loader.ml -o hol_loader.cmx
 
-hol_lib_inlined.ml: hol_lib.ml inline_load.ml ; \
+hol_lib_inlined.ml: ${HOLSRC} inline_load.ml ; \
         HOLLIGHT_DIR="`pwd`" ocaml inline_load.ml hol_lib.ml hol_lib_inlined.ml -omit-prelude
 
 hol_lib.cmo: pa_j.cmo hol_lib_inlined.ml hol_loader.cmo bignum.cmo ; \

--- a/unit_tests.ml
+++ b/unit_tests.ml
@@ -11,3 +11,19 @@ assert (`F` = `false`);;
 assert (`!(x:A). P x` = `forall (x:A). P x`);;
 assert (`?(x:A). P x` = `exists (x:A). P x`);;
 assert (`?!(x:A). P x` = `existsunique (x:A). P x`);;
+
+(* ------------------------------------------------------------------------- *)
+(* Test COMPUTE_CONVs.                                                       *)
+(* ------------------------------------------------------------------------- *)
+
+assert (rhs (concl (NUM_COMPUTE_CONV `if x then 1 + 2 else 3 + 4`))
+              = `if x then 1 + 2 else 3 + 4`);;
+assert (rhs (concl (NUM_COMPUTE_CONV `if true then 1 + 2 else 3 + 4`))
+              = `3`);;
+assert (rhs (concl (NUM_COMPUTE_CONV `\x. x + (1 + 2)`))
+        = `\x. x + (1 + 2)`);;
+assert (rhs (concl (NUM_COMPUTE_CONV `(\x. x + (1 + 2)) (3 + 4)`))
+        = `10`);;
+(* Arguments are reduced when the fn is a constant. *)
+assert (rhs (concl (NUM_COMPUTE_CONV `(unknown_fn:num->num) (1+2)`))
+        = `(unknown_fn:num->num) 3`);;


### PR DESCRIPTION
This patch adds conversions of num/int/rat/real/word that use the Compute module to evaluate expressions.
They are named `*_COMPUTE_CONV` and uses the 'weak' reduction (`Compute.WEAK_CBV_CONV`).
Additionally, an if-then-else expression is configured to be reduced only when the branch is constant.

These new conversions are different from

- `*_RED_CONV` because `*_RED_CONV` cannot recursively traverse subexpression (e.g., `NUM_RED_CONV` cannot reduce `` `1 + (2 + 3)` ``)
- Also different from `*_REDUCE_CONV` because `*_REDUCE_CONV` tries to recursively reduce every subexpression (e.g., `` `if unknown_cond then 1 + 2 else 3 + 4` ``, `` `\x. x + (1 + 2)` ``).