### PR TITLE
Add `Compute.basic_compset`

### DIFF
--- a/unit_tests.ml
+++ b/unit_tests.ml
@@ -30,6 +30,44 @@ assert (rhs (concl (NUM_COMPUTE_CONV `(unknown_fn:num->num) (1+2)`))
 
 
 (* ------------------------------------------------------------------------- *)
+(* Test basic_compset.                                                       *)
+(* ------------------------------------------------------------------------- *)
+
+let _ =
+  let open Compute in
+  let cs = basic_compset() in
+  let cv = CBV_CONV cs in
+  let wcv = WEAK_CBV_CONV cs in begin
+
+  (* Generalized abstraction *)
+  assert (rhs (concl (wcv `(\((x,y),(z,w)). x + y + z + w) ((1,2),(3,4))`)) =
+          `1 + 2 + 3 + 4`);
+  assert (rhs (concl (cv `(\((x,y),(z,w)). x + y + z + w) ((1,2),(3,4))`)) =
+          `1 + 2 + 3 + 4`);
+
+  (* Abstraction body is not reduced if WEAK_CBV is used *)
+  assert (rhs (concl (wcv
+          `(\((x,y),(z,w)):(num#num)#(num#num). true /\ true)`)) =
+        `(\((x,y),(z,w)):(num#num)#(num#num). true /\ true)`);
+  assert (rhs (concl (cv
+          `(\((x,y),(z,w)):(num#num)#(num#num). true /\ true)`)) =
+          `(\((x,y),(z,w)):(num#num)#(num#num). true)`);
+
+  (* Match *)
+  assert (
+    rhs (concl (wcv `match [1;2;3;4;5] with [] -> [] | CONS x (CONS y z) -> z`)) =
+    `[3; 4; 5]`);
+  assert (
+    rhs (concl (cv `match [1;2;3;4;5] with [] -> [] | CONS x (CONS y z) -> z`)) =
+    `[3; 4; 5]`);
+
+  (* Let *)
+  assert (rhs (concl (wcv `let x = 1 in x + 2`)) = `1 + 2`);
+  assert (rhs (concl (cv `let x = 1 in x + 2`)) = `1 + 2`);
+  end;;
+
+
+(* ------------------------------------------------------------------------- *)
 (* Test check_axioms.                                                        *)
 (* ------------------------------------------------------------------------- *)
 


### PR DESCRIPTION
This adds `Compute.basic_compset ()` which returns a new compset based on the rewrite rules registered at `basic_rewrites()` as well as conversions registered at `basic_convs()`.
This is different from `Compute.bool_compset () ` which only has a few primitive set of rewrite rules on logical operations. `basic_rewrites()` and `basic_convs()` can reduce generalized abstraction, `match`, some structural operators like `FST` and `SND`, etc. These sets are also extensible because one can add more rules using `extend_basic_rewrites` and conversions to `extend_basic_convs`. Compared to `Compute.bool_compset ()`, `Compute.basic_compset ()` can be more easily used as a base compset for versatile evaluator with basic functionalities already equipped.
Also, for usability `let_CONV` is added to the returned compset.