### PR TITLE
Add `HOLLIGHT_LOAD_PATH`

### DIFF
--- a/Help/load_path.hlp
+++ b/Help/load_path.hlp
@@ -12,6 +12,10 @@ filenames. An initial dollar sign {$} in each path is interpreted as a
 reference to the current setting of {hol_dir}. To get an actual {$} character
 at the start of the filename, use two dollar signs {$$}.
 
+Additional paths can be added to {load_path} by setting the
+{HOLLIGHT_LOAD_PATH} environment variable. Each path must be separated by
+an OS-specific delimiter (':' for Unix and ';' for Windows).
+
 \FAILURE
 Not applicable.
 

--- a/Help/loadt.hlp
+++ b/Help/loadt.hlp
@@ -10,6 +10,10 @@ The function {loadt} takes a string indicating an OCaml file name as
 argument and loads it. If the filename is relative, it is found on the load
 path {load_path}, and it is then loaded, updating the list of loaded files.
 
+Additional paths can be added to {load_path} by setting the
+{HOLLIGHT_LOAD_PATH} environment variable. Each path must be separated by
+an OS-specific delimiter (':' for Unix and ';' for Windows).
+
 \FAILURE
 {loadt} will fail if the file named by the argument does not exist in
 the search path. It will of course fail if the file is not a valid OCaml

--- a/hol_loader.ml
+++ b/hol_loader.ml
@@ -48,8 +48,8 @@ let hol_expand_directory s =
 let load_path = ref ["."; "$"];;
 
 (* Read the HOLLIGHT_LOAD_PATH env variable *)
-try
-  let p = Sys.getenv "HOLLIGHT_LOAD_PATH" in
+let p = try Sys.getenv "HOLLIGHT_LOAD_PATH" with Not_found -> "" in
+let new_paths:string list =
   (* Separator, to split p into multiple paths *)
   let sep = if Sys.win32 then ';' else (* Cygwin and Unix *) ':' in
 
@@ -58,6 +58,8 @@ try
   let escaped = ref false in
   let quote = ref None (* either Some '\'' or Some '"' *) in
   let l = String.length p in
+  let new_paths = ref [] in
+
   for i = 0 to l - 1 do
     (* Was p[i-1] a backslash ('\\')? *)
     if !escaped then escaped := false else
@@ -72,7 +74,7 @@ try
 
     (* Is it a separator (':' or ';')? *)
     if p.[i] = sep then begin
-      load_path := !load_path @ [String.sub p !prev_idx (i - !prev_idx)];
+      new_paths := !new_paths @ [String.sub p !prev_idx (i - !prev_idx)];
       prev_idx := i + 1
     end else if p.[i] = '\\' then
       (* escaping the next character *)
@@ -82,9 +84,10 @@ try
       quote := Some p.[i]
     else ()
   done;
-  (* add the remaining string to load_path *)
-  load_path := !load_path @ [String.sub p !prev_idx (l - !prev_idx)]
-with Not_found -> ();;
+  (* add the remaining string *)
+  new_paths := !new_paths @ [String.sub p !prev_idx (l - !prev_idx)];
+  !new_paths in
+load_path := !load_path @ new_paths;;
 
 let loaded_files = ref [];;
 

--- a/hol_loader.ml
+++ b/hol_loader.ml
@@ -67,8 +67,7 @@ let new_paths:string list =
     (* Is it inside a quotation ("..." or '...')? *)
     if !quote <> None then
       (* Is p[i] closing the quotation? *)
-      if (p.[i] = '\'' || p.[i] = '"') && !quote = Some p.[i]
-      then quote := None
+      if !quote = Some p.[i] then quote := None
       else ()
     else
 


### PR DESCRIPTION
This patch updates `load_path` to read paths from `HOLLIGHT_LOAD_PATH`. Hence, this affects `needs` and `loadt` which depends on `load_path` when the loading path is relative.
Multiple paths can be added using an OS-specific separator, which is ':' for Unix and ';' for Windows.
Also, quotations ("/home/path with space", 'my dir') and escaping (the backslash prefix) is supported.

This resolves #129 . I chose `HOLLIGHT_LOAD_PATH` instead of `HOLLIGHT_PATH` because `HOLLIGHT_LOAD_PATH` seemed more clearer to me.