### PR TITLE
Small functionality updates and minor bug fixes

### DIFF
--- a/Help/PRINT_GOAL_TAC.hlp
+++ b/Help/PRINT_GOAL_TAC.hlp
@@ -13,6 +13,6 @@ to standard output.
 Never fails.
 
 \SEEALSO
-print_goal, print_goalstack, print_term
+print_goal, print_goalstack, print_term, PRINT_TERM_CONV, REMARK_TAC
 
 \ENDDOC

--- a/Help/PRINT_TERM_CONV.hlp
+++ b/Help/PRINT_TERM_CONV.hlp
@@ -1,0 +1,17 @@
+\DOC PRINT_TERM_CONV
+
+\TYPE {PRINT_TERM_CONV : conv}
+
+\SYNOPSIS
+Prints the term to standard output.
+
+\DESCRIBE
+The conversion {PRINT_TERM_CONV} prints the current term to standard output.
+
+\FAILURE
+Never fails.
+
+\SEEALSO
+print_term, PRINT_GOAL_TAC, REMARK_TAC
+
+\ENDDOC

--- a/Help/REMARK_TAC.hlp
+++ b/Help/REMARK_TAC.hlp
@@ -1,0 +1,19 @@
+\DOC REMARK_TAC
+
+\TYPE {REMARK_TAC : string -> tactic}
+
+\SYNOPSIS
+A tactic version of {remark}.
+
+\DESCRIBE
+Given any goal {A ?- p}, the tactic {REMARK_TAC s} prints the string s
+to standard output.
+As {remark} does, this outputs a string only if {verbose} flag is set.
+
+\FAILURE
+Never fails.
+
+\SEEALSO
+PRINT_GOAL_TAC, remark, verbose
+
+\ENDDOC

--- a/Help/remark.hlp
+++ b/Help/remark.hlp
@@ -26,6 +26,6 @@ Never fails.
 }
 
 \SEEALSO
-report, verbose.
+report, verbose, REMARK_TAC.
 
 \ENDDOC

--- a/equal.ml
+++ b/equal.ml
@@ -339,3 +339,9 @@ let CACHE_CONV =
               with Failure _ ->
                   let th = conv tm in
                   (net := enter [] (tm,ALPHA_HACK th) (!net); th);;
+
+(* ------------------------------------------------------------------------- *)
+(* A printer.                                                                *)
+(* ------------------------------------------------------------------------- *)
+
+let PRINT_TERM_CONV t = Format.printf "%a\n" pp_print_qterm t; ALL_CONV t;;

--- a/hol_loader.ml
+++ b/hol_loader.ml
@@ -99,7 +99,14 @@ let file_on_path p s =
 let load_on_path p s =
   let s' = file_on_path p s in
   let fileid = (Filename.basename s',Digest.file s') in
-  (use_file s'; loaded_files := fileid::(!loaded_files));;
+  let old_loaded_files = !loaded_files in
+  try
+    use_file s'; loaded_files := fileid::(!loaded_files)
+  with f ->
+    (* Exception in use_file implies that s' could not be loaded and
+       use_file_raise_failure was true. Rollback any updates in
+       loaded_files. *)
+    (loaded_files := old_loaded_files; raise f);;
 
 let loads s = load_on_path ["$"] s;;
 

--- a/lib.ml
+++ b/lib.ml
@@ -464,8 +464,9 @@ let time f x =
       result
   with e ->
       let finish_time = Sys.time() in
-      Format.print_string("Failed after (user) CPU time of "^
-                          (string_of_float(finish_time -. start_time))^": ");
+      let msg = Printexc.to_string e in
+      report("Failed after (user) CPU time of "^
+             (string_of_float(finish_time -. start_time))^": "^msg);
       raise e;;
 
 (* ------------------------------------------------------------------------- *)

--- a/printer.ml
+++ b/printer.ml
@@ -147,7 +147,7 @@ let print_all_thm = ref true;;
 (* ------------------------------------------------------------------------- *)
 (* Flag controlling whether types of subterms must be printed.               *)
 (* 0: Do not print the types of subterms                                     *)
-(* 1 (defualt) : Only print types containing invented type variables         *)
+(* 1 (default) : Only print types containing invented type variables         *)
 (* 2: Print the types of constants and variables                             *)
 (* ------------------------------------------------------------------------- *)
 

--- a/tactics.ml
+++ b/tactics.ml
@@ -820,6 +820,7 @@ let (pp_print_goalstack:Format.formatter->goalstack->unit) =
 let print_goal = pp_print_goal Format.std_formatter;;
 let print_goalstack = pp_print_goalstack Format.std_formatter;;
 let PRINT_GOAL_TAC: tactic = fun gl -> print_goal gl; ALL_TAC gl;;
+let REMARK_TAC (s:string): tactic = fun gl -> remark s; ALL_TAC gl;;
 
 (* ------------------------------------------------------------------------- *)
 (* Convert a tactic into a refinement on head subgoal in current state.      *)


### PR DESCRIPTION
This addes the following small printer functionalities:

- PRINT_TERM_CONV: the conversion briefly discussed in Zulip
- REMARK_TAC: a tactic version of `remark`

Also this fixes the following small bugs:

(1) `use_file_raise_failure` must reset `loaded_file`.

When `use_file_raise_failure` is used, any failure in the loading files will lose the defined OCaml bindings so far. This is expected behavior, but one inconvenience is that the `loaded_file` variable is still correspondingly updated. This makes the `needs` unable to load the file again.

An example:
```
(* file0.ml *)
loadt "file1.ml";;
loadt "file2.ml";;
(* file1.ml *)
let x = 1;;
(* file2.ml *)
failwith".";;
```

In HOL Light:

```
  # use_file_raise_failure := true;;
  val it : unit = ()
  # loadt "file0.ml";;
  val x : int = 1
  - : unit = ()
  Exception: Failure "fail".
  Exception: Failure "Error in included file /home/aqjune/hol-light/file2.ml".
  Exception: Failure "Error in included file /home/aqjune/hol-light/file0.ml". <-- these tree exceptions are expected
  # loaded_files;;
  val it : (string * Digest.t) list ref =
  {contents =
    [("file1.ml", "D*Ec\003yC@\026u"); <--- this is not expected!
    ...
    ]
```

This makes running `needs "file1.ml";;` again impossible, even if its OCaml bindings have been all dropped. This happens when loading "{arm,x86}/proofs/base.ml";; with `use_file_raise_failure := true`;; set. This patch makes `use_file_raise_failure` completely recover `loaded_files`.

(2) Nested `time` was printing weirdly when Exception was happening.

For example, when `time (fun () -> time (fun () -> failwith "aa") ()) ();;` was run, it was printing something that cannot be unciphered. After this patch, now it prints ok:
```
  # time (fun () -> time (fun () -> failwith "aa") ()) ();;
  Failed after (user) CPU time of 9.99999997475e-07: Failure("aa")
  Failed after (user) CPU time of 9.29999999926e-05: Failure("aa")
  Exception: Failure "aa".
```