### PR TITLE
Allow benign redefinition in new_inductive_definition when extra fora…

### DIFF
--- a/ind_defs.ml
+++ b/ind_defs.ml
@@ -349,8 +349,8 @@ let prove_inductive_relations_exist,new_inductive_definition =
       let crels = zip grels schems in
       let clauses' = map (subst crels) clauses in
       clauses',snd(strip_comb(hd schems)) in
-  let find_redefinition tm (rth,ith,cth as trip) =
-    if aconv tm (concl rth) then trip else failwith "find_redefinition" in
+  let find_redefinition tm (rth,ith,cth as trip):((thm*thm*thm)*thm) =
+    (trip,PART_MATCH I rth tm) in
   let prove_inductive_properties tm =
     let clauses = conjuncts tm in
     let clauses',fvs = unschematize_clauses clauses in
@@ -361,8 +361,10 @@ let prove_inductive_relations_exist,new_inductive_definition =
     let th2 = generalize_schematic_variables true fvs th1 in
     derive_existence th2
   and new_inductive_definition tm =
-    try let th = tryfind (find_redefinition tm) (!the_inductive_definitions) in
-        warn true "Benign redefinition of inductive predicate"; th
+    try let tm' = snd(strip_forall tm) in
+        let th,_ = tryfind (find_redefinition tm')
+          (!the_inductive_definitions) in
+        warn true "Benign redefinition of inductive predicate";th
     with Failure _ ->
     let fvs,th1 = prove_inductive_properties tm in
     let th2 = generalize_schematic_variables true fvs th1 in

--- a/unit_tests.ml
+++ b/unit_tests.ml
@@ -94,6 +94,20 @@ let _ = define `(h_benign:A list -> num) [] = 0 /\
 
 
 (* ------------------------------------------------------------------------- *)
+(* Test benign redefinition of an inductive datatype.                        *)
+(* ------------------------------------------------------------------------- *)
+
+let _ = new_inductive_definition
+  `(forall s. steps (step:S->S->bool) 0 (s:S) (s:S)) /\
+   (forall s s'' n. (exists s'. step s s' /\ steps step n s' s'')
+      ==> steps step (n+1) s s'')`;;
+let _ = new_inductive_definition
+  `(forall s. steps (step:S->S->bool) 0 (s:S) (s:S)) /\
+   (forall s s'' n. (exists s'. step s s' /\ steps step n s' s'')
+      ==> steps step (n+1) s s'')`;;
+
+
+(* ------------------------------------------------------------------------- *)
 (* Test functions in lib.                                                    *)
 (* ------------------------------------------------------------------------- *)
 


### PR DESCRIPTION
…lls are added

This patch extends `new_inductive_definition` to support benign redefinition when `new_inductive_definition` has to add extra universally quantified variables to the specification.

An example is `steps` in s2n-bignum:

```
 # new_inductive_definition `(!s. steps (step:S->S->bool) 0 (s:S) (s:S)) /\
     (!s s'' n. (?s'. step s s' /\ steps step n s' s'') ==> steps step (n+1) s s'')`;;
 val it : thm * thm * thm =
    (|- forall step.
            (forall s. steps step 0 s s) /\
            (forall s s'' n.
                 (exists s'.
                      step s s' /\
                      steps step n s' s'')
                 ==> steps step (n + 1) s s''),
     |- forall step steps'.
            (forall s. steps' 0 s s) /\
            (forall s s'' n.
                 (exists s'.
                      step s s' /\
                      steps' n s' s'')
                 ==> steps' (n + 1) s s'')
            ==> (forall a0 a1 a2.
                     steps step a0 a1 a2
                     ==> steps' a0 a1 a2),
     |- forall step a0 a1 a2.
            steps step a0 a1 a2 <=>
            a0 = 0 /\ a2 = a1 \/
            (exists n.
                 a0 = n + 1 /\
                 (exists s'.
                      step a1 s' /\
                      steps step n s' a2)))
 # new_inductive_definition `(!s. steps (step:S->S->bool) 0 (s:S) (s:S)) /\
     (!s s'' n. (?s'. step s s' /\ steps step n s' s'') ==> steps step (n+1) s s'')`;;
 Exception: Failure "dest_var: not a variable".
```

This is failing because `new_inductive_definition` internally adds extra quantified variables, specifically the `step` variable (the fourth line of the above output). To fix this, this patch adds a fix using `PART_MATCH` which is analogous to what `define` in define.ml does.