### PR TITLE
metis.ml: replace sqrt by float_sqrt (one occurrence)

### DIFF
--- a/metis.ml
+++ b/metis.ml
@@ -5279,7 +5279,7 @@ let multInt =
     match Int.maxInt with
       None -> (fun x -> fun y -> Some (x * y))
     | Some m ->
-        let m = Real.floor (Stdlib.sqrt (Real.fromInt m))
+        let m = Real.floor (float_sqrt (Real.fromInt m))
       in
         fun x -> fun y -> if x <= m && y <= m then Some (x * y) else None
       ;;

--- a/metis.ml
+++ b/metis.ml
@@ -5279,7 +5279,7 @@ let multInt =
     match Int.maxInt with
       None -> (fun x -> fun y -> Some (x * y))
     | Some m ->
-        let m = Real.floor (sqrt (Real.fromInt m))
+        let m = Real.floor (Stdlib.sqrt (Real.fromInt m))
       in
         fun x -> fun y -> if x <= m && y <= m then Some (x * y) else None
       ;;


### PR DESCRIPTION
Hi. I don't know exactly why but I get some typing error when tracing HOL-Light proofs with https://github.com/Deducteam/hol2dk because the only occurrence of sqrt in metis.ml is not qualified and thus depends on the context it is evaluated, which I believe is not what is wanted. This PR proposes to fix this.