### PR TITLE
mcp: add proof recording and tactic replay

### DIFF
--- a/mcp/SKILL.md
+++ b/mcp/SKILL.md
@@ -179,6 +179,8 @@ CONV_TAC WORD_RULE
 - **hol_load** — load a HOL Light file via `needs` (e.g., `hol_load` with file `"Library/words.ml"`)
 - **hol_interrupt** — send SIGINT to cancel a hung tactic (e.g., when `MESON_TAC` diverges)
 - **hol_help** — return this tactic reference (SKILL.md). Call before your first proof.
+- **start_recording** — record all tactic applications to a JSONL file for later replay
+- **stop_recording** — stop recording and return the file path
 
 ## General advice
 

--- a/mcp/hol-mcp.toml
+++ b/mcp/hol-mcp.toml
@@ -11,3 +11,7 @@ timeout = 600
 
 # Maximum characters for eval output before truncation.
 max_output_chars = 4000
+
+# Auto-record proof tactics to this directory (recording.jsonl).
+# Relative paths resolved against CWD. Also settable via HOL_RECORDING_DIR env var.
+# recording_dir = "/path/to/work"

--- a/mcp/hol-mcp.toml
+++ b/mcp/hol-mcp.toml
@@ -15,3 +15,10 @@ max_output_chars = 4000
 # Auto-record proof tactics to this directory (recording.jsonl).
 # Relative paths resolved against CWD. Also settable via HOL_RECORDING_DIR env var.
 # recording_dir = "/path/to/work"
+
+# Replay a tactic prefix on startup to restore proof state.
+# replay_init: ML file to #use before replaying (e.g., load project dependencies).
+# replay_prefix: JSONL file of tactics to replay (same format as recording.jsonl).
+# Also settable via HOL_REPLAY_INIT and HOL_REPLAY_PREFIX env vars.
+# replay_init = "/path/to/init.ml"
+# replay_prefix = "/path/to/prefix.jsonl"

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -60,6 +60,10 @@ _lock = threading.Lock()
 _helpers_loaded = False
 _start_time = None
 
+# Proof recording state
+_recording_path = None  # path to JSONL file; None = not recording
+_recording = []         # list of {"action": "tactic", "tactic": ..., "total_goals": ...}
+
 # Queue-based sentinel signaling: reader thread produces results, eval consumes.
 # Eliminates race conditions — queue.get() is atomic consumption.
 _result_queue = queue.Queue(maxsize=1)
@@ -238,8 +242,23 @@ def eval(code: str, timeout: int = None, max_output_chars: int = None) -> str:
          "full_output_chars": int, "time_seconds": float}
     """
     import json as _json
-    raw, elapsed = _eval_code(code, timeout)
-    raw = _strip_ansi(raw)
+    # Detect recording patterns before eval
+    is_bt = _is_backtrack(code) if _recording_path else None
+    tac = _extract_e_tactic(code) if (_recording_path and not is_bt) else None
+
+    with _lock:
+        _start_hol()
+        _load_helpers()
+        raw, elapsed = _eval_raw(code, timeout)
+        raw = _strip_ansi(raw)
+        # Record e(...) and b() calls while still holding the lock
+        if _recording_path:
+            if is_bt:
+                _record_backtrack(1)
+            elif tac and not _is_error_output(raw):
+                gs_raw, _ = _eval_raw("print_string (mcp_json_after_tactic ()); print_newline ()")
+                _record_tactic(tac, _extract_json(gs_raw))
+
     limit = max_output_chars if max_output_chars is not None else MAX_OUTPUT_CHARS
     full_len = len(raw)
     output, truncated = _truncate(raw, limit)
@@ -282,7 +301,12 @@ def apply_tactic(tactic: str, timeout: int = None) -> str:
             f'with Failure s -> print_string (mcp_json_error s) '
             f'| e -> print_string (mcp_json_error (Printexc.to_string e))); '
             f'print_newline ()')
-    return _extract_json(_eval_code(code, timeout)[0])
+    with _lock:
+        _start_hol()
+        _load_helpers()
+        result = _extract_json(_eval_raw(code, timeout)[0])
+        _record_tactic(tactic, result)
+    return result
 
 
 @mcp.tool()
@@ -304,7 +328,12 @@ def apply_tactics(tactics: list[str], timeout: int = None) -> str:
         return '{"error":"empty tactic list"}'
     tac_list = "[" + "; ".join(tactics) + "]"
     code = (f'print_string (mcp_json_apply_tactics {tac_list}); print_newline ()')
-    return _extract_json(_eval_code(code, timeout)[0])
+    with _lock:
+        _start_hol()
+        _load_helpers()
+        result = _extract_json(_eval_raw(code, timeout)[0])
+        _record_tactics_batch(tactics, result)
+    return result
 
 
 @mcp.tool()
@@ -341,7 +370,12 @@ def backtrack(steps: int = 1) -> str:
 
     Returns JSON goal state or {"error": "..."} if can't back up.
     """
-    return _extract_json(_eval_json(f"mcp_json_backtrack {steps}")[0])
+    with _lock:
+        _start_hol()
+        _load_helpers()
+        result = _extract_json(_eval_raw(f'print_string (mcp_json_backtrack {steps}); print_newline ()')[0])
+        _record_backtrack(steps)
+    return result
 
 
 @mcp.tool()
@@ -489,6 +523,113 @@ def _json_quote(s: str) -> str:
     return '"' + s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n") + '"'
 
 
+# --- Proof recording helpers ---
+
+def _flush_recording():
+    """Write the current recording to disk.
+    Rewrites the full file each time so backtrack deletions are reflected.
+    """
+    import json
+    if _recording_path:
+        with open(_recording_path, 'w') as f:
+            for entry in _recording:
+                f.write(json.dumps(entry) + "\n")
+
+
+def _record_tactic(tactic_str, result_json_str):
+    """Record a successful tactic application."""
+    import json
+    if not _recording_path:
+        return
+    try:
+        result = json.loads(result_json_str)
+    except (json.JSONDecodeError, TypeError):
+        return
+    if "error" in result:
+        return
+    total = 0 if result.get("proved") else result.get("total_goals", 0)
+    _recording.append({"action": "tactic", "tactic": tactic_str, "total_goals": total})
+    _flush_recording()
+
+
+def _record_backtrack(steps):
+    """Remove the last N tactic entries from the recording."""
+    if not _recording_path:
+        return
+    removed = 0
+    while removed < steps and _recording:
+        if _recording[-1]["action"] == "tactic":
+            _recording.pop()
+            removed += 1
+        else:
+            break
+    _flush_recording()
+
+
+def _record_tactics_batch(tactics, result_json_str):
+    """Record successful tactics from an apply_tactics batch."""
+    import json
+    if not _recording_path:
+        return
+    try:
+        result = json.loads(result_json_str)
+    except (json.JSONDecodeError, TypeError):
+        return
+    if "error" in result and "step" in result:
+        # Error at step N: record tactics 0..N-1 (0-indexed, step is 1-indexed)
+        succeeded = result["step"] - 1
+    elif "steps" in result:
+        succeeded = result["steps"]
+    else:
+        return
+    for tac in tactics[:succeeded]:
+        _recording.append({"action": "tactic", "tactic": tac, "total_goals": 0})
+    if succeeded > 0:
+        _flush_recording()
+
+
+def _extract_e_tactic(code: str) -> str | None:
+    """Extract tactic string from 'e(TACTIC);;' pattern using paren counting."""
+    stripped = code.strip()
+    m = re.match(r'\s*e\s*\(', stripped)
+    if not m:
+        return None
+    start = m.end()
+    depth = 1
+    in_str = False
+    in_backtick = False
+    esc = False
+    for i in range(start, len(stripped)):
+        c = stripped[i]
+        if esc:
+            esc = False
+            continue
+        if c == '\\' and in_str:
+            esc = True
+            continue
+        if c == '"' and not in_backtick:
+            in_str = not in_str
+            continue
+        if c == '`' and not in_str:
+            in_backtick = not in_backtick
+            continue
+        if in_str or in_backtick:
+            continue
+        if c == '(':
+            depth += 1
+        elif c == ')':
+            depth -= 1
+            if depth == 0:
+                return stripped[start:i].strip()
+    return None
+
+
+def _is_backtrack(code: str) -> bool:
+    """Check if code is a b() call."""
+    stripped = code.strip().rstrip(';').strip()
+    return bool(re.match(r'^b\s*\(\s*\)\s*$', stripped))
+
+
 def _extract_json(output: str) -> str:
     """Extract JSON from print_string output. The output contains the JSON
     printed to stdout, followed by 'val it : unit = ()'."""
@@ -524,6 +665,39 @@ def _extract_json(output: str) -> str:
                 if depth == 0:
                     return stripped[idx:i+1]
     return '{"error":' + _json_quote(f"Unexpected output: {stripped[:200]}") + '}'
+
+
+@mcp.tool()
+def start_recording(path: str) -> str:
+    """Start recording proof tactics to a JSONL file.
+
+    Args:
+        path: File path for the recording (e.g., "/tmp/recording.jsonl")
+
+    Returns confirmation message.
+    """
+    global _recording_path, _recording
+    with _lock:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        _recording_path = path
+        _recording = []
+        _flush_recording()
+    return f"Recording started: {path}"
+
+
+@mcp.tool()
+def stop_recording() -> str:
+    """Stop recording proof tactics and return the recording path.
+
+    Returns the path to the recording file.
+    """
+    global _recording_path
+    with _lock:
+        path = _recording_path
+        _recording_path = None
+    if path:
+        return f"Recording stopped: {path}"
+    return "No recording was active."
 
 
 def main():

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -185,6 +185,48 @@ def _load_helpers():
         _helpers_loaded = True
     else:
         raise RuntimeError(f"Failed to load MCP helpers: {result}")
+    _replay_prefix()
+
+
+def _replay_prefix():
+    """Replay a tactic prefix on startup to restore proof state.
+
+    Loads replay_init (ML file) then replays replay_prefix (JSONL of tactics).
+    Both are optional; configured via hol-mcp.toml or env vars.
+    """
+    init_path = _config.get("replay_init") or os.environ.get("HOL_REPLAY_INIT")
+    prefix_path = _config.get("replay_prefix") or os.environ.get("HOL_REPLAY_PREFIX")
+    if not init_path and not prefix_path:
+        return
+    if init_path:
+        result, _ = _eval_raw(f'#use "{_ocaml_escape(init_path)}"')
+        if _is_error_output(_strip_ansi(result)):
+            return
+    if not prefix_path or not os.path.exists(prefix_path):
+        return
+    import json
+    replayed = []
+    try:
+        with open(prefix_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                entry = json.loads(line)
+                if entry.get("action") == "tactic":
+                    result, _ = _eval_raw(f'e({entry["tactic"]})')
+                    if _is_error_output(_strip_ansi(result)):
+                        for _ in range(len(replayed)):
+                            _eval_raw("b()")
+                        return
+                    replayed.append(entry)
+    except (json.JSONDecodeError, KeyError, OSError):
+        for _ in range(len(replayed)):
+            _eval_raw("b()")
+        return
+    global _recording
+    _recording = replayed
+    _flush_recording()
 
 
 def _eval_raw(code: str, timeout: int = None) -> tuple[str, float]:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -64,6 +64,13 @@ _start_time = None
 _recording_path = None  # path to JSONL file; None = not recording
 _recording = []         # list of {"action": "tactic", "tactic": ..., "total_goals": ...}
 
+# Auto-recording: if recording_dir is set in config or env, enable recording at startup.
+_auto_record_dir = _config.get("recording_dir") or os.environ.get("HOL_RECORDING_DIR")
+if _auto_record_dir:
+    _auto_record_dir = os.path.abspath(_auto_record_dir)
+    os.makedirs(_auto_record_dir, exist_ok=True)
+    _recording_path = os.path.join(_auto_record_dir, "recording.jsonl")
+
 # Queue-based sentinel signaling: reader thread produces results, eval consumes.
 # Eliminates race conditions — queue.get() is atomic consumption.
 _result_queue = queue.Queue(maxsize=1)

--- a/mcp/smoke_test.py
+++ b/mcp/smoke_test.py
@@ -37,7 +37,7 @@ async def main():
             # Check tools registered
             tools = await session.list_tools()
             tool_names = sorted(t.name for t in tools.tools)
-            check("tools registered", tool_names == ["apply_tactic", "apply_tactics", "backtrack", "eval", "goal_state", "hol_help", "hol_interrupt", "hol_load", "hol_restart", "hol_status", "hol_type", "prove", "search_theorems", "set_goal"],
+            check("tools registered", tool_names == ["apply_tactic", "apply_tactics", "backtrack", "eval", "goal_state", "hol_help", "hol_interrupt", "hol_load", "hol_restart", "hol_status", "hol_type", "prove", "search_theorems", "set_goal", "start_recording", "stop_recording"],
                   f"got {tool_names}")
 
             # eval — basic arithmetic (now returns JSON)
@@ -143,6 +143,20 @@ async def main():
             r = await session.call_tool("eval", {"code": "1 + 1", "timeout": 30})
             ev = json.loads(r.content[0].text)
             check("eval: custom timeout", "2" in ev["output"], ev["output"])
+
+            # start_recording / stop_recording
+            import tempfile, os
+            rec_path = os.path.join(tempfile.mkdtemp(), "test_recording.jsonl")
+            r = await session.call_tool("start_recording", {"path": rec_path})
+            check("start_recording", "Recording started" in r.content[0].text, r.content[0].text)
+            await session.call_tool("eval", {"code": "g `!n. n + 0 = n`"})
+            await session.call_tool("apply_tactic", {"tactic": "GEN_TAC THEN ARITH_TAC"})
+            r = await session.call_tool("stop_recording", {})
+            check("stop_recording", "Recording stopped" in r.content[0].text, r.content[0].text)
+            check("recording file exists", os.path.exists(rec_path), rec_path)
+            with open(rec_path) as f:
+                entries = [json.loads(line) for line in f if line.strip()]
+            check("recording has entries", len(entries) > 0 and entries[0]["action"] == "tactic", str(entries[:2]))
 
             # hol_restart (run last — kills the process)
             r = await session.call_tool("hol_restart", {})

--- a/mcp/test_server.py
+++ b/mcp/test_server.py
@@ -5,6 +5,7 @@ shared across all tests via module-scoped fixture.
 """
 
 import json
+import os
 import pytest
 import server
 
@@ -302,3 +303,107 @@ def test_hol_help_tool():
     result = server.hol_help()
     assert "## Core tactics" in result
     assert "prove" in result.lower()
+
+
+# --- start_recording / stop_recording tools ---
+
+def test_start_recording(tmp_path):
+    path = str(tmp_path / "rec.jsonl")
+    result = server.start_recording(path)
+    assert "Recording started" in result
+    assert os.path.exists(path)
+    server.stop_recording()
+
+
+def test_stop_recording_returns_path(tmp_path):
+    path = str(tmp_path / "rec.jsonl")
+    server.start_recording(path)
+    result = server.stop_recording()
+    assert path in result
+
+
+def test_stop_recording_when_inactive():
+    result = server.stop_recording()
+    assert "No recording" in result
+
+
+def test_recording_captures_apply_tactic(tmp_path):
+    path = str(tmp_path / "rec.jsonl")
+    server.start_recording(path)
+    server.set_goal("`!n. n + 0 = n`")
+    server.apply_tactic("GEN_TAC THEN ARITH_TAC")
+    server.stop_recording()
+    with open(path) as f:
+        entries = [json.loads(line) for line in f if line.strip()]
+    assert len(entries) == 1
+    assert entries[0]["action"] == "tactic"
+    assert entries[0]["tactic"] == "GEN_TAC THEN ARITH_TAC"
+
+
+def test_recording_backtrack_removes_entry(tmp_path):
+    path = str(tmp_path / "rec.jsonl")
+    server.start_recording(path)
+    server.set_goal("`!n. n + 0 = n`")
+    server.apply_tactic("GEN_TAC")
+    server.backtrack()
+    server.stop_recording()
+    with open(path) as f:
+        entries = [json.loads(line) for line in f if line.strip()]
+    assert len(entries) == 0
+
+
+def test_recording_skips_failed_tactic(tmp_path):
+    path = str(tmp_path / "rec.jsonl")
+    server.start_recording(path)
+    server.set_goal("`T`")
+    server.apply_tactic("FAKE_NONEXISTENT_TAC")
+    server.stop_recording()
+    with open(path) as f:
+        entries = [json.loads(line) for line in f if line.strip()]
+    assert len(entries) == 0
+
+
+def test_start_recording_creates_parent_dirs(tmp_path):
+    path = str(tmp_path / "nested" / "dir" / "rec.jsonl")
+    server.start_recording(path)
+    assert os.path.exists(path)
+    server.stop_recording()
+
+
+def test_recording_captures_apply_tactics_batch(tmp_path):
+    path = str(tmp_path / "rec.jsonl")
+    server.start_recording(path)
+    server.set_goal("`!n. n + 0 = n`")
+    server.apply_tactics(["GEN_TAC", "ARITH_TAC"])
+    server.stop_recording()
+    with open(path) as f:
+        entries = [json.loads(line) for line in f if line.strip()]
+    assert len(entries) == 2
+    assert entries[0]["tactic"] == "GEN_TAC"
+    assert entries[1]["tactic"] == "ARITH_TAC"
+
+
+def test_recording_captures_eval_e_tactic(tmp_path):
+    path = str(tmp_path / "rec.jsonl")
+    server.start_recording(path)
+    server.set_goal("`!n. n + 0 = n`")
+    server.eval("e(GEN_TAC);;")
+    server.stop_recording()
+    with open(path) as f:
+        entries = [json.loads(line) for line in f if line.strip()]
+    assert len(entries) == 1
+    assert entries[0]["tactic"] == "GEN_TAC"
+
+
+def test_recording_backtrack_removes_last(tmp_path):
+    path = str(tmp_path / "rec.jsonl")
+    server.start_recording(path)
+    server.set_goal("`!m n. m + n = n + m`")
+    server.apply_tactic("GEN_TAC")
+    server.apply_tactic("GEN_TAC")
+    server.backtrack()
+    server.stop_recording()
+    with open(path) as f:
+        entries = [json.loads(line) for line in f if line.strip()]
+    assert len(entries) == 1
+    assert entries[0]["tactic"] == "GEN_TAC"


### PR DESCRIPTION
Adds proof recording to the MCP server so tactic sequences can be captured and replayed, enabling proof resumption after session crashes or context window exhaustion.

### Motivation

During long interactive proofs, the LLM may run out of context window or the session may crash. Without recording, all proof progress is lost and tactics must be manually re-applied. This PR adds recording and replay so proofs can resume from where they left off.

### Changes

#### Proof recording tools

New `start_recording(path)` and `stop_recording()` tools write tactic applications to a JSONL file. Recording hooks in `eval`, `apply_tactic`, `apply_tactics`, and `backtrack` capture the proof trace automatically. The `eval` hook uses paren-counting to extract tactics from `e(TACTIC);;` calls.

Recording format (one JSON object per line):
```
    {"action": "tactic", "tactic": "GEN_TAC", "total_goals": 1}
    {"action": "tactic", "tactic": "ARITH_TAC", "total_goals": 0}
```
#### Auto-recording via config

Set `recording_dir` in `hol-mcp.toml` or `HOL_RECORDING_DIR` env var to start recording automatically at server startup, without the LLM needing to call `start_recording`.

#### Tactic replay on startup

Configure `replay_prefix` (JSONL file) and optionally `replay_init` (ML file to `#use` first) to restore proof state on startup. The server replays the tactic sequence and seeds the recording so new tactics append to the prefix. Backtracks cleanly on any failure.

All recording operations are synchronized with the existing `_lock` to prevent races with concurrent tool calls.

