### PR TITLE
pa_j: accept camlp5 8.05 for OCaml 5.4

### DIFF
--- a/pa_j/chooser.sh
+++ b/pa_j/chooser.sh
@@ -20,7 +20,7 @@ CAMLP5_FULL_VERSION=`camlp5 -v 2>&1 | cut -f3 -d' ' | cut -f1-3 -d'.' | cut -f1 
 
 if test ${OCAML_BINARY_VERSION} = "3.0"
 then echo "pa_j_${OCAML_VERSION}.ml"
-elif test ${CAMLP5_FULL_VERSION} = "8.04.00"
+elif test ${CAMLP5_BINARY_VERSION} = "8.04" -o ${CAMLP5_BINARY_VERSION} = "8.05"
 then
   if test ${OCAML_BINARY_VERSION} = "5.4"
   then echo "pa_j_5.4_8.04.00.ml"


### PR DESCRIPTION
nixpkgs 26.05 ships OCaml 5.4.1 and camlp5 8.05.01 which isn't currently supported by `pa_j/chooser.sh`.
This PR add scamlp5 8.05.01 to the accepted versions.

- All proofs in mlkem-native pass fine with that version combination: https://github.com/pq-code-package/mlkem-native/pull/1711
- Resolves https://github.com/jrh13/hol-light/issues/177