### PR TITLE
Make define_record_type idempotent via a dedicated cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,8 @@ jobs:
           ./UnitTests/basic_tests.native
           ./UnitTests/printer_tests.byte
           ./UnitTests/printer_tests.native
+          ./UnitTests/records.byte
+          ./UnitTests/records.native
 
   test3:
     runs-on: ubuntu-22.04
@@ -133,4 +135,6 @@ jobs:
           ./UnitTests/basic_tests.native
           ./UnitTests/printer_tests.byte
           ./UnitTests/printer_tests.native
+          ./UnitTests/records.byte
+          ./UnitTests/records.native
 

--- a/Help/define_auto_record_type.hlp
+++ b/Help/define_auto_record_type.hlp
@@ -1,0 +1,55 @@
+\DOC define_auto_record_type
+
+\TYPE {define_auto_record_type : string -> thm * thm * thm}
+
+\SYNOPSIS
+Defines a record type and registers all its component properties.
+
+\DESCRIBE
+The function {define_auto_record_type} takes a record type specification in the
+same syntax as {define_record_type}, namely
+{
+   "op = { fld1 : ty1 ; fld2 : ty2 ; ... ; fldn : tyn }"
+}
+\noindent It first calls {define_record_type} to define the type {op}, its
+single constructor {op}{_RECORD} and the {read}/{write} component for each
+field, returning the same triple {(ith,rth,cth)} of induction, recursion and
+component-characterization theorems.
+
+In addition, it derives and adds to the relevant global databases the standard
+properties of the fields as components, so that subsequent automation (for
+instance component-based simplification and orthogonality reasoning) can use
+them without further manual proof. Specifically it registers, for every field:
+the read-over-write theorems ({record_read_write_thms}), the strongly-valid,
+valid, extensionally-valid and weakly-valid component theorems, and the
+orthogonality theorems for each pair of distinct fields
+({record_orthogonality_thms}).
+
+Because it is layered on {define_record_type}, re-issuing an identical
+definition is benign in the same way (see {define_record_type}); note however
+that the component database entries are re-added on each such call.
+
+\FAILURE
+Fails under the same conditions as {define_record_type}: an ill-formed
+specification, a clash with an existing unrelated definition of the type or a
+field constant, or a redefinition of the type name with a different field list.
+
+\EXAMPLE
+{
+  # needs "Library/records.ml";;
+  # let point_INDUCT,point_RECURSION,point_COMPONENTS =
+      define_auto_record_type "point = { xc: num; yc: num }";;
+  ...
+}
+\noindent After this, the read-over-write and orthogonality laws for {xc} and
+{yc} are available to component-based automation, and can also be obtained
+explicitly:
+{
+  # record_read_write_thms (point_INDUCT,point_COMPONENTS);;
+  # record_orthogonality_thms (point_INDUCT,point_COMPONENTS);;
+}
+
+\SEEALSO
+define_record_type, define_type.
+
+\ENDDOC

--- a/Help/define_record_type.hlp
+++ b/Help/define_record_type.hlp
@@ -1,0 +1,84 @@
+\DOC define_record_type
+
+\TYPE {define_record_type : string -> thm * thm * thm}
+
+\SYNOPSIS
+Defines a record type with named fields and their read/write components.
+
+\DESCRIBE
+Given a string specifying a record type, {define_record_type} defines a new
+single-constructor inductive type together with a {read}/{write} component (see
+{Library/components.ml}) for each field. The input string has the form
+{
+   "op = { fld1 : ty1 ; fld2 : ty2 ; ... ; fldn : tyn }"
+}
+\noindent where {op} is the name of the type operator to be defined, {fld1},
+..., {fldn} are the field names and {ty1}, ..., {tyn} are the corresponding
+types. As with {define_type}, the number of distinct type variables among the
+{tyi} determines the arity of the type operator {op}.
+
+The underlying type is defined with a single constructor called {op}{_RECORD},
+taking the field types as arguments in order. For each
+field {fldi} a constant of that name is introduced by {new_specification},
+characterized as a component: {read fldi} projects out the field and
+{write fldi} updates it. The function returns a triple {(ith,rth,cth)}: the
+induction theorem, the recursion theorem and the conjunction of the component
+read/write characterizations.
+
+The type name is recorded, so that a subsequent call to {define_record_type}
+with the same type name is benign: if the fields are identical the previously
+computed theorems are returned (with a warning), rather than the constants
+being redeclared. See {\FAILURE} for the case of a clashing redefinition.
+
+To additionally register all the standard component properties (read-over-write
+laws, validity and orthogonality) with the component database, use
+{define_auto_record_type}.
+
+\FAILURE
+Fails if the string is not a syntactically valid record specification, if the
+type {op}{_RECORD} or one of the field constants is already in use for an
+unrelated definition, or if the type name has already been used by
+{define_record_type} with a different list of fields (in which case the error
+message is {"define_record_type: type op already defined with different
+fields"}).
+
+\EXAMPLE
+Here we define a record type of two-dimensional points with natural-number
+coordinates:
+{
+  # needs "Library/records.ml";;
+  # define_record_type "point = { xc: num; yc: num }";;
+  val it : thm * thm * thm =
+    (|- !P. (!a0 a1. P (point_RECORD a0 a1)) ==> (!x. P x),
+     |- !f. ?fn. !a0 a1. fn (point_RECORD a0 a1) = f a0 a1,
+     |- (!a0 a1. read xc (point_RECORD a0 a1) = a0) /\
+        (!a0' a0 a1. write xc a0' (point_RECORD a0 a1) = point_RECORD a0' a1) /\
+        (!a0 a1. read yc (point_RECORD a0 a1) = a1) /\
+        (!a1' a0 a1. write yc a1' (point_RECORD a0 a1) = point_RECORD a0 a1'))
+}
+\noindent Re-issuing the identical definition is benign and returns the same
+theorems:
+{
+  # define_record_type "point = { xc: num; yc: num }";;
+  Warning: Benign redefinition of record type
+  val it : thm * thm * thm = ...
+}
+\noindent Since the field types here mention two distinct type variables {A}
+and {B}, the following defines {pair} as a binary type operator rather than a
+type constant:
+{
+  # define_record_type "pair = { fst_c: A; snd_c: B }";;
+  val it : thm * thm * thm =
+    (|- !P. (!a0 a1. P (pair_RECORD a0 a1)) ==> (!x. P x),
+     |- !f. ?fn. !a0 a1. fn (pair_RECORD a0 a1) = f a0 a1,
+     |- (!a0 a1. read fst_c (pair_RECORD a0 a1) = a0) /\
+        (!a0' a0 a1. write fst_c a0' (pair_RECORD a0 a1) = pair_RECORD a0' a1) /\
+        (!a0 a1. read snd_c (pair_RECORD a0 a1) = a1) /\
+        (!a1' a0 a1. write snd_c a1' (pair_RECORD a0 a1) = pair_RECORD a0 a1'))
+}
+\noindent so that, for example, {`p:(num,bool)pair`} is a well-formed type.
+
+\SEEALSO
+define_auto_record_type, define_type.
+
+\ENDDOC

--- a/Library/records.ml
+++ b/Library/records.ml
@@ -28,12 +28,23 @@ let parse_record_specification =
                else tyname,rs
           | _ -> raise Noparse;;
 
+let the_record_types = ref
+ ([]:(string*((string*hol_type)list*(thm*thm*thm)))list);;
+
 let define_record_type =
   let tweak = (MATCH_MP o prove)
    (`(?r. P r) /\ (?w. Q w) ==> ?c. P(read c) /\ Q(write c)`,
     REWRITE_TAC[EXISTS_COMPONENT; read; write] THEN MESON_TAC[]) in
   fun s ->
     let tyname,fields = parse_record_specification s in
+    if can (assoc tyname) (!the_record_types) then
+      let ofields,othms = assoc tyname (!the_record_types) in
+      if ofields = fields
+      then (warn true "Benign redefinition of record type"; othms)
+      else failwith
+        ("define_record_type: type "^tyname^
+         " already defined with different fields")
+    else
     let tyname_rec = tyname^"_RECORD" in
     let ith,rth =
      define_type_raw [mk_vartype tyname,[tyname_rec,map snd fields]] in
@@ -58,7 +69,9 @@ let define_record_type =
                     let rethm = prove_recursive_functions_exist rth rcdef in
                     new_specification [fnm] (tweak (CONJ rethm wethm)))
       fnms avs in
-    ith,rth,end_itlist CONJ defs;;
+    let result = ith,rth,end_itlist CONJ defs in
+    the_record_types := (tyname,(fields,result))::(!the_record_types);
+    result;;
 
 (* ------------------------------------------------------------------------- *)
 (* Get the components out of a record definition                             *)

--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,22 @@ UnitTests/printer_tests.native: UnitTests/printer_tests_inlined.cmx hol_lib.cmxa
 UnitTests/printer_tests_inlined.cmx: UnitTests/printer_tests_inlined.ml hol_lib.cmxa hol.sh ; \
         ./hol.sh compile UnitTests/printer_tests_inlined.ml
 
+# UnitTests/records.ml: record type (Library/records.ml) checks.
+UnitTests/records_inlined.ml: UnitTests/records.ml inline_load.ml hol.sh ; \
+        ./hol.sh inline-load UnitTests/records.ml UnitTests/records_inlined.ml
+UnitTests/records.byte: UnitTests/records_inlined.ml hol_lib.cmo hol.sh ; \
+        ocamlfind ocamlc -package zarith -linkpkg -pp "`./hol.sh -pp`" \
+        -I . bignum.cmo hol_loader.cmo hol_lib.cmo \
+        UnitTests/records_inlined.ml -o UnitTests/records.byte
+UnitTests/records.native: UnitTests/records_inlined.cmx hol_lib.cmxa hol.sh ; \
+        ./hol.sh link UnitTests/records_inlined.cmx -o UnitTests/records.native
+UnitTests/records_inlined.cmx: UnitTests/records_inlined.ml hol_lib.cmxa hol.sh ; \
+        ./hol.sh compile UnitTests/records_inlined.ml
+
 default: hol_lib.cma hol_lib.cmxa \
          UnitTests/basic_tests.byte UnitTests/basic_tests.native \
-         UnitTests/printer_tests.byte UnitTests/printer_tests.native
+         UnitTests/printer_tests.byte UnitTests/printer_tests.native \
+         UnitTests/records.byte UnitTests/records.native
 endif
 
 # Build a standalone hol image called "hol" (needs Linux and DMTCP)
@@ -275,6 +288,8 @@ clean:; \
          UnitTests/basic_tests.byte UnitTests/basic_tests.native \
          UnitTests/printer_tests_inlined.* \
          UnitTests/printer_tests.byte UnitTests/printer_tests.native \
+         UnitTests/records_inlined.* \
+         UnitTests/records.byte UnitTests/records.native \
          ocaml-hol hol.sh hol hol.ckpt \
          hol.multivariate hol.multivariate.ckpt \
          hol.sosa hol.sosa.ckpt \

--- a/UnitTests/basic_tests.ml
+++ b/UnitTests/basic_tests.ml
@@ -225,58 +225,6 @@ let test_fn = function
 set_jrh_lexer;;
 
 (* ------------------------------------------------------------------------- *)
-(* Test record types (Library/components.ml and Library/records.ml).          *)
-(* ------------------------------------------------------------------------- *)
-
-needs "Library/records.ml";;
-
-let point_INDUCT,point_RECURSION,point_COMPONENTS =
-  define_auto_record_type
-   "test_point = { xcoord: num; ycoord: num }";;
-
-(* Check that the induction, recursion and component theorems exist *)
-let _ = concl point_INDUCT;;
-let _ = concl point_RECURSION;;
-let _ = concl point_COMPONENTS;;
-
-(* Check that read/write theorems were generated *)
-assert (length (get_record_components point_COMPONENTS) = 2);;
-
-(* Check read-write laws *)
-let rw_thms = record_read_write_thms (point_INDUCT, point_COMPONENTS);;
-assert (length rw_thms = 2);;
-
-(* Check strongly_valid_component theorems *)
-let sv_thms =
-  record_strongly_valid_component_thms (point_INDUCT, point_COMPONENTS);;
-assert (length sv_thms = 2);;
-
-(* Check orthogonality theorems (2 fields => 2 ordered pairs) *)
-let orth_thms = record_orthogonality_thms (point_INDUCT, point_COMPONENTS);;
-assert (length orth_thms = 2);;
-
-(* Prove: writing xcoord updates it correctly *)
-let XCOORD_READ_WRITE = prove
- (`!x s:test_point. read xcoord (write xcoord x s) = x`,
-  GEN_TAC THEN MATCH_MP_TAC point_INDUCT THEN
-  REWRITE_TAC[point_COMPONENTS]);;
-
-(* Prove: writing xcoord leaves ycoord intact *)
-let YCOORD_INTACT = prove
- (`!x s:test_point. read ycoord (write xcoord x s) = read ycoord s`,
-  GEN_TAC THEN MATCH_MP_TAC point_INDUCT THEN
-  REWRITE_TAC[point_COMPONENTS]);;
-
-(* Test a record with 3 fields *)
-let triple_INDUCT,triple_RECURSION,triple_COMPONENTS =
-  define_auto_record_type
-   "test_triple = { first: num; second: bool; third: num }";;
-
-assert (length (get_record_components triple_COMPONENTS) = 3);;
-assert (length (record_orthogonality_thms
-                  (triple_INDUCT, triple_COMPONENTS)) = 6);;
-
-(* ------------------------------------------------------------------------- *)
 (* Test check_axioms.                                                        *)
 (* ------------------------------------------------------------------------- *)
 

--- a/UnitTests/records.ml
+++ b/UnitTests/records.ml
@@ -1,0 +1,79 @@
+(* ========================================================================= *)
+(*             HOL LIGHT unit tests for record types                         *)
+(*                                                                           *)
+(* Tests for Library/components.ml and Library/records.ml.                    *)
+(* ========================================================================= *)
+
+needs "Library/records.ml";;
+
+let point_INDUCT,point_RECURSION,point_COMPONENTS =
+  define_auto_record_type
+   "test_point = { xcoord: num; ycoord: num }";;
+
+(* Check that the induction, recursion and component theorems exist *)
+let _ = concl point_INDUCT;;
+let _ = concl point_RECURSION;;
+let _ = concl point_COMPONENTS;;
+
+(* Check that read/write theorems were generated *)
+assert (length (get_record_components point_COMPONENTS) = 2);;
+
+(* Check read-write laws *)
+let rw_thms = record_read_write_thms (point_INDUCT, point_COMPONENTS);;
+assert (length rw_thms = 2);;
+
+(* Check strongly_valid_component theorems *)
+let sv_thms =
+  record_strongly_valid_component_thms (point_INDUCT, point_COMPONENTS);;
+assert (length sv_thms = 2);;
+
+(* Check orthogonality theorems (2 fields => 2 ordered pairs) *)
+let orth_thms = record_orthogonality_thms (point_INDUCT, point_COMPONENTS);;
+assert (length orth_thms = 2);;
+
+(* Prove: writing xcoord updates it correctly *)
+let XCOORD_READ_WRITE = prove
+ (`!x s:test_point. read xcoord (write xcoord x s) = x`,
+  GEN_TAC THEN MATCH_MP_TAC point_INDUCT THEN
+  REWRITE_TAC[point_COMPONENTS]);;
+
+(* Prove: writing xcoord leaves ycoord intact *)
+let YCOORD_INTACT = prove
+ (`!x s:test_point. read ycoord (write xcoord x s) = read ycoord s`,
+  GEN_TAC THEN MATCH_MP_TAC point_INDUCT THEN
+  REWRITE_TAC[point_COMPONENTS]);;
+
+(* Test a record with 3 fields *)
+let triple_INDUCT,triple_RECURSION,triple_COMPONENTS =
+  define_auto_record_type
+   "test_triple = { first: num; second: bool; third: num }";;
+
+assert (length (get_record_components triple_COMPONENTS) = 3);;
+assert (length (record_orthogonality_thms
+                  (triple_INDUCT, triple_COMPONENTS)) = 6);;
+
+(* ------------------------------------------------------------------------- *)
+(* Test benign redefinition: defining the same record type twice must        *)
+(* succeed and return the identical theorems from the cache, rather than     *)
+(* failing with "new_basic_type_definition: Constant(s) already in use".     *)
+(* ------------------------------------------------------------------------- *)
+
+let point2_INDUCT,point2_RECURSION,point2_COMPONENTS =
+  define_record_type "test_point = { xcoord: num; ycoord: num }";;
+
+assert (concl point2_INDUCT = concl point_INDUCT);;
+assert (concl point2_RECURSION = concl point_RECURSION);;
+assert (concl point2_COMPONENTS = concl point_COMPONENTS);;
+
+(* ------------------------------------------------------------------------- *)
+(* Test that redefining a record type with different fields fails cleanly    *)
+(* with the dedicated error message.                                         *)
+(* ------------------------------------------------------------------------- *)
+
+try
+  let _ = define_record_type "test_point = { xcoord: bool; ycoord: num }" in
+  assert false
+with Failure msg ->
+       assert (msg =
+         "define_record_type: type test_point already defined with different fields")
+   | Assert_failure _ as e -> raise e;;


### PR DESCRIPTION
Calling define_record_type twice with the same specification previously failed with "new_basic_type_definition: Constant(s) already in use", because it unconditionally re-ran define_type_raw and new_specification.

Add a dedicated the_record_types cache keyed on the parsed (tyname, fields): a repeat with identical fields returns the cached theorems (warning "Benign redefinition of record type"), while a repeat with the same type name but different fields fails with a clear message rather than a low-level kernel error.

Move the record-type tests out of UnitTests/basic_tests.ml into a new UnitTests/records.ml (wired into the Makefile and CI), and add tests for the benign-redefinition and clashing-redefinition behaviour. Document define_record_type and define_auto_record_type under Help/.