### PR TITLE
mcp: config-aware hol_restart with optional HOL+checkpoint rebuild

### DIFF
--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run unit tests
         run: |
           eval $(opam env)
-          cd mcp && uv run pytest test_server.py -v
+          cd mcp && uv run pytest test_server.py test_restart.py -v
 
       - name: Run smoke tests
         run: |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -44,7 +44,7 @@ See [TUTORIAL.md](TUTORIAL.md) for more examples (including s2n-bignum ARM proof
 | `hol_type` | Get the type of a term | Raw text |
 | `hol_load` | Load a HOL Light file via `needs` | Structured JSON |
 | `hol_interrupt` | Cancel a long-running command | Status message |
-| `hol_restart` | Kill and restart the HOL Light subprocess | Status message |
+| `hol_restart` | Reload config; optionally rebuild a checkpoint; restart HOL | Structured JSON |
 | `hol_status` | Check process health, uptime, config, checkpoint | Structured JSON |
 | `hol_help` | Return tactic reference and proof guide (SKILL.md) | Markdown text |
 | `start_recording` | Start recording proof tactics to a JSONL file | Status message |
@@ -98,9 +98,32 @@ timeout = 600
 
 # Maximum characters for eval output before truncation.
 max_output_chars = 4000
+
+# Checkpoint recipes for hol_restart(rebuild_hol_and_checkpoint=true).
+# "base" is vanilla HOL Light and needs no recipe; other checkpoints require one.
+# Example recipe with s2n-bignum ARM infrastructure (uncomment to enable):
+# [checkpoint_recipes.gcm]
+# include_dirs = ["/path/to/s2n-bignum"]
+# loads = ['needs "arm/proofs/base.ml"', 'needs "common/gcm.ml"']
 ```
 
-Use `hol_status` to verify which config file and checkpoint are active.
+`hol_restart(checkpoint="gcm")` selects `gcm` for one invocation without
+modifying the config. `hol_restart(rebuild_hol_and_checkpoint=true)`
+synchronously runs `make clean` and `make` to rebuild HOL Light from source,
+then rebuilds the selected checkpoint recipe, before restarting HOL. Because it
+rebuilds HOL Light itself, it commonly takes several minutes and must be
+requested explicitly. The `base` checkpoint can be rebuilt without a recipe;
+any other checkpoint requires an explicit `[checkpoint_recipes.<name>]` entry,
+otherwise the rebuild fails rather than replacing a custom checkpoint with bare
+HOL. If the build or checkpoint creation fails, the MCP server remains
+available but stops HOL and rejects proof work until the build is fixed and
+`hol_restart(rebuild_hol_and_checkpoint=true)` succeeds.
+
+The restart response reports the active and configured checkpoints, process
+IDs, startup mode, changed config values, and failure diagnostics. Use
+`hol_status` to inspect the active checkpoint, its captured file fingerprint,
+whether its files have changed since startup, and whether a rebuild is
+required.
 
 ## Usage
 
@@ -138,8 +161,8 @@ The server includes a built-in `hol_help` tool that returns the full tactic refe
 
 ```bash
 cd mcp
-uv run pytest test_server.py -v       # 48 unit tests
-uv run python smoke_test.py           # 37 MCP integration checks
+uv run pytest test_server.py test_restart.py -v   # 63 unit tests
+uv run python smoke_test.py                        # 37 MCP integration checks
 ```
 
 First run includes HOL Light startup (~75s cold, ~2s with checkpoint).

--- a/mcp/SKILL.md
+++ b/mcp/SKILL.md
@@ -23,7 +23,7 @@ HOL Light is a classical higher-order logic theorem prover. The law of excluded 
 6. **backtrack** — undo if a tactic made things worse
 7. Repeat 2–6 until proved
 8. **hol_status** — check if HOL Light is alive (useful for debugging)
-9. **hol_restart** — restart HOL Light if it has died or is in a bad state
+9. **hol_restart** — restart HOL Light if it has died or is in a bad state; pass `checkpoint=` to switch checkpoint for one restart, or `rebuild_hol_and_checkpoint=true` to rebuild HOL Light and its checkpoint from source (a multi-minute operation)
 
 Always read the goal state carefully before choosing a tactic. The structured JSON tells you exactly what hypotheses you have and what you need to show.
 

--- a/mcp/TUTORIAL.md
+++ b/mcp/TUTORIAL.md
@@ -138,7 +138,7 @@ apply_tactic  "DISJ2_TAC THEN REWRITE_TAC[EVEN_ADD] THEN ASM_REWRITE_TAC[NOT_EVE
 6. **backtrack** — undo if a tactic didn't help
 7. Repeat until `"proved":true`
 8. **hol_status** — check if HOL Light is alive (useful for debugging)
-9. **hol_restart** — restart HOL Light if it has died or is in a bad state
+9. **hol_restart** — restart HOL Light if it has died or is in a bad state; pass `checkpoint=` to switch checkpoint for one restart, or `rebuild_hol_and_checkpoint=true` to rebuild HOL Light and its checkpoint from source (a multi-minute operation)
 
 **Utility tools:** **hol_type** (get term types), **hol_load** (load files), **hol_interrupt** (cancel hung tactics), **hol_help** (tactic reference), **start_recording** / **stop_recording** (record tactics to JSONL for replay)
 

--- a/mcp/hol-mcp.toml
+++ b/mcp/hol-mcp.toml
@@ -22,3 +22,16 @@ max_output_chars = 4000
 # Also settable via HOL_REPLAY_INIT and HOL_REPLAY_PREFIX env vars.
 # replay_init = "/path/to/init.ml"
 # replay_prefix = "/path/to/prefix.jsonl"
+
+# Recipes describe how hol_restart(rebuild_hol_and_checkpoint=true) rebuilds a
+# checkpoint. Relative include directories are resolved against this config file.
+# The "base" checkpoint is vanilla HOL Light and can be rebuilt without a recipe;
+# every other checkpoint MUST define one here or the rebuild fails (we never
+# rebuild a custom checkpoint as bare HOL).
+#
+# Example recipe with s2n-bignum ARM infrastructure. Uncomment and adjust
+# include_dirs to your s2n-bignum checkout to enable
+# hol_restart(checkpoint="gcm", rebuild_hol_and_checkpoint=true).
+# [checkpoint_recipes.gcm]
+# include_dirs = ["/path/to/s2n-bignum"]
+# loads = ['needs "arm/proofs/base.ml"', 'needs "common/gcm.ml"']

--- a/mcp/make_checkpoint.py
+++ b/mcp/make_checkpoint.py
@@ -41,6 +41,10 @@ def parse_args():
     )
     p.add_argument("--name", default="base",
                    help="Checkpoint name (creates hol-<name>.ckpt/). Default: base")
+    p.add_argument(
+        "--output-dir",
+        help="Write checkpoint files to this directory instead of hol-<name>.ckpt/",
+    )
     p.add_argument("-I", dest="include_dirs", action="append", default=[],
                    help="Add OCaml include directory (can be repeated)")
     p.add_argument("extra_loads", nargs="*", metavar="EXPR",
@@ -119,7 +123,11 @@ def send_and_wait(proc, code, error_msg):
 
 def main():
     args = parse_args()
-    ckpt_dir = os.path.join(HOL_DIR, f"hol-{args.name}.ckpt")
+    ckpt_dir = (
+        os.path.abspath(args.output_dir)
+        if args.output_dir
+        else os.path.join(HOL_DIR, f"hol-{args.name}.ckpt")
+    )
     ocaml_hol = os.path.join(HOL_DIR, "ocaml-hol")
 
     # Validate prerequisites
@@ -159,7 +167,7 @@ def main():
         env["HOLLIGHT_LOAD_PATH"] = f"{extra}:{existing}" if existing else extra
 
     # Print plan
-    print(f"Checkpoint: hol-{args.name}.ckpt/", flush=True)
+    print(f"Checkpoint: {ckpt_dir}/", flush=True)
     if args.include_dirs:
         print(f"Include dirs: {args.include_dirs}", flush=True)
     if args.extra_loads:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 """MCP server for HOL Light theorem prover."""
 
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import json
 import os
 import queue
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 
@@ -13,6 +18,8 @@ HOL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MCP_DIR = os.path.dirname(os.path.abspath(__file__))
 SENTINEL = "HOL_MCP_DONE_a7f3b2e1"
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+CHECKPOINT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+RESTART_HEARTBEAT_SECONDS = 15
 
 
 def _load_config():
@@ -39,11 +46,133 @@ def _load_config():
 
 
 _config, CONFIG_PATH = _load_config()
-TIMEOUT = _config.get("timeout", int(os.environ.get("HOL_TIMEOUT", "600")))
-CHECKPOINT_NAME = _config.get("checkpoint", os.environ.get("HOL_CHECKPOINT", "base"))
-MAX_OUTPUT_CHARS = _config.get("max_output_chars", int(os.environ.get("HOL_MAX_OUTPUT", "4000")))
 
-from mcp.server.fastmcp import FastMCP
+
+def _positive_int(value, name):
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _optional_string(value, name):
+    if value is not None and not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    return value
+
+
+def _validate_checkpoint_name(name):
+    if not isinstance(name, str) or not CHECKPOINT_RE.fullmatch(name) or ".." in name:
+        raise ValueError(
+            "checkpoint must start with an alphanumeric character and contain "
+            "only letters, digits, '.', '_', or '-'"
+        )
+    return name
+
+
+def _effective_config(config, config_path):
+    """Validate raw TOML data and return its effective runtime values."""
+    if not isinstance(config, dict):
+        raise ValueError("configuration root must be a TOML table")
+
+    checkpoint = _validate_checkpoint_name(
+        config.get("checkpoint", os.environ.get("HOL_CHECKPOINT", "base"))
+    )
+    timeout = _positive_int(
+        config.get("timeout", int(os.environ.get("HOL_TIMEOUT", "600"))),
+        "timeout",
+    )
+    max_output = _positive_int(
+        config.get(
+            "max_output_chars", int(os.environ.get("HOL_MAX_OUTPUT", "4000"))
+        ),
+        "max_output_chars",
+    )
+
+    recording_dir = config.get("recording_dir") or os.environ.get(
+        "HOL_RECORDING_DIR"
+    )
+    recording_dir = _optional_string(recording_dir, "recording_dir")
+    if recording_dir:
+        recording_dir = os.path.abspath(recording_dir)
+
+    replay_init = _optional_string(
+        config.get("replay_init") or os.environ.get("HOL_REPLAY_INIT"),
+        "replay_init",
+    )
+    replay_prefix = _optional_string(
+        config.get("replay_prefix") or os.environ.get("HOL_REPLAY_PREFIX"),
+        "replay_prefix",
+    )
+
+    raw_recipes = config.get("checkpoint_recipes", {})
+    if not isinstance(raw_recipes, dict):
+        raise ValueError("checkpoint_recipes must be a TOML table")
+    config_dir = os.path.dirname(config_path) if config_path else os.getcwd()
+    recipes = {}
+    for name, raw_recipe in raw_recipes.items():
+        _validate_checkpoint_name(name)
+        if not isinstance(raw_recipe, dict):
+            raise ValueError(f"checkpoint_recipes.{name} must be a TOML table")
+        include_dirs = raw_recipe.get("include_dirs", [])
+        loads = raw_recipe.get("loads", [])
+        if (
+            not isinstance(include_dirs, list)
+            or not all(isinstance(path, str) for path in include_dirs)
+        ):
+            raise ValueError(
+                f"checkpoint_recipes.{name}.include_dirs must be an array of strings"
+            )
+        if (
+            not isinstance(loads, list)
+            or not all(isinstance(load, str) for load in loads)
+        ):
+            raise ValueError(
+                f"checkpoint_recipes.{name}.loads must be an array of strings"
+            )
+        recipes[name] = {
+            "include_dirs": [
+                path
+                if os.path.isabs(path)
+                else os.path.abspath(os.path.join(config_dir, path))
+                for path in include_dirs
+            ],
+            "loads": list(loads),
+        }
+
+    return {
+        "raw": config,
+        "checkpoint": checkpoint,
+        "timeout": timeout,
+        "max_output_chars": max_output,
+        "recording_dir": recording_dir,
+        "replay_init": replay_init,
+        "replay_prefix": replay_prefix,
+        "checkpoint_recipes": recipes,
+    }
+
+
+def _config_snapshot(config):
+    return {
+        key: config[key]
+        for key in (
+            "checkpoint",
+            "timeout",
+            "max_output_chars",
+            "recording_dir",
+            "replay_init",
+            "replay_prefix",
+            "checkpoint_recipes",
+        )
+    }
+
+
+_runtime_config = _effective_config(_config, CONFIG_PATH)
+TIMEOUT = _runtime_config["timeout"]
+CONFIGURED_CHECKPOINT = _runtime_config["checkpoint"]
+CHECKPOINT_NAME = CONFIGURED_CHECKPOINT
+MAX_OUTPUT_CHARS = _runtime_config["max_output_chars"]
+
+from mcp.server.fastmcp import Context, FastMCP
 mcp = FastMCP("hol-light",
     instructions="HOL Light theorem prover. Call hol_help() for a tactic reference and proof guide.")
 
@@ -57,17 +186,23 @@ def _read_skill():
 
 _proc = None
 _lock = threading.Lock()
+_restart_lock = threading.Lock()
 _helpers_loaded = False
 _start_time = None
+_startup_mode = None
+_checkpoint_active = False
+_checkpoint_error = None
+_checkpoint_fingerprint = None
+_restart_required = False
+_restart_error = None
 
 # Proof recording state
 _recording_path = None  # path to JSONL file; None = not recording
 _recording = []         # list of {"action": "tactic", "tactic": ..., "total_goals": ...}
 
 # Auto-recording: if recording_dir is set in config or env, enable recording at startup.
-_auto_record_dir = _config.get("recording_dir") or os.environ.get("HOL_RECORDING_DIR")
+_auto_record_dir = _runtime_config["recording_dir"]
 if _auto_record_dir:
-    _auto_record_dir = os.path.abspath(_auto_record_dir)
     os.makedirs(_auto_record_dir, exist_ok=True)
     _recording_path = os.path.join(_auto_record_dir, "recording.jsonl")
 
@@ -77,18 +212,18 @@ _result_queue = queue.Queue(maxsize=1)
 _reader_buf = []
 
 
-def _reader_thread(proc):
+def _reader_thread(proc, result_queue, reader_buf):
     while True:
         line = proc.stdout.readline()
         if not line:
             # Process died — signal immediately so callers don't hang
-            _result_queue.put("[HOL Light process died unexpectedly]")
+            result_queue.put("[HOL Light process died unexpectedly]")
             break
         if SENTINEL in line:
-            _result_queue.put("".join(_reader_buf).strip())
-            _reader_buf.clear()
+            result_queue.put("".join(reader_buf).strip())
+            reader_buf.clear()
         else:
-            _reader_buf.append(line)
+            reader_buf.append(line)
 
 
 def _opam_env():
@@ -114,18 +249,76 @@ def _opam_env():
     return env
 
 
-def _start_hol():
-    global _proc
+def _checkpoint_dir(name):
+    return os.path.join(HOL_DIR, f"hol-{name}.ckpt")
+
+
+def _checkpoint_files(name):
+    ckpt_dir = _checkpoint_dir(name)
+    if not os.path.isdir(ckpt_dir):
+        return []
+    return sorted(
+        os.path.join(ckpt_dir, filename)
+        for filename in os.listdir(ckpt_dir)
+        if filename.startswith("ckpt_") and filename.endswith(".dmtcp")
+    )
+
+
+def _fingerprint_checkpoint(name):
+    fingerprint = []
+    for path in _checkpoint_files(name):
+        try:
+            stat = os.stat(path)
+        except OSError:
+            return None
+        fingerprint.append(
+            {
+                "name": os.path.basename(path),
+                "size": stat.st_size,
+                "mtime_ns": stat.st_mtime_ns,
+            }
+        )
+    return fingerprint or None
+
+
+def _start_hol(
+    checkpoint=None,
+    force_cold=False,
+    checkpoint_error=None,
+    allow_restart_required=False,
+):
+    global _proc, _result_queue, _reader_buf
+    global _start_time, _startup_mode, _checkpoint_active
+    global _checkpoint_error, _checkpoint_fingerprint, CHECKPOINT_NAME
+    if _restart_required and not allow_restart_required:
+        raise RuntimeError(
+            f"HOL is unavailable after a failed HOL/checkpoint rebuild: {_restart_error}. "
+            "Fix the build and run hol_restart(rebuild_hol_and_checkpoint=true)."
+        )
     if _proc is not None:
         return
-    ckpt_dir = os.path.join(HOL_DIR, f"hol-{CHECKPOINT_NAME}.ckpt")
-    ckpt_files = sorted(
-        f for f in os.listdir(ckpt_dir) if f.startswith("ckpt_") and f.endswith(".dmtcp")
-    ) if os.path.isdir(ckpt_dir) else []
-    if ckpt_files:
+    checkpoint = checkpoint or CHECKPOINT_NAME
+    CHECKPOINT_NAME = checkpoint
+    ckpt_files = _checkpoint_files(checkpoint)
+    use_checkpoint = bool(ckpt_files) and not force_cold
+    _checkpoint_fingerprint = _fingerprint_checkpoint(checkpoint)
+    _checkpoint_active = use_checkpoint
+    _startup_mode = "checkpoint" if use_checkpoint else "cold"
+    if checkpoint_error:
+        _checkpoint_error = checkpoint_error
+    elif not ckpt_files:
+        _checkpoint_error = (
+            f"No usable checkpoint files found in {_checkpoint_dir(checkpoint)}"
+        )
+    else:
+        _checkpoint_error = None
+
+    _result_queue = queue.Queue(maxsize=1)
+    _reader_buf = []
+    if use_checkpoint:
         _proc = subprocess.Popen(
             ["dmtcp_restart", "--no-strict-checking", "--coord-port", "0"] +
-            [os.path.join(ckpt_dir, f) for f in ckpt_files],
+            ckpt_files,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -146,9 +339,12 @@ def _start_hol():
             bufsize=1,
             env=_opam_env(),
         )
-    global _start_time
     _start_time = time.time()
-    t = threading.Thread(target=_reader_thread, args=(_proc,), daemon=True)
+    t = threading.Thread(
+        target=_reader_thread,
+        args=(_proc, _result_queue, _reader_buf),
+        daemon=True,
+    )
     t.start()
 
 
@@ -194,8 +390,8 @@ def _replay_prefix():
     Loads replay_init (ML file) then replays replay_prefix (JSONL of tactics).
     Both are optional; configured via hol-mcp.toml or env vars.
     """
-    init_path = _config.get("replay_init") or os.environ.get("HOL_REPLAY_INIT")
-    prefix_path = _config.get("replay_prefix") or os.environ.get("HOL_REPLAY_PREFIX")
+    init_path = _runtime_config["replay_init"]
+    prefix_path = _runtime_config["replay_prefix"]
     if not init_path and not prefix_path:
         return
     if init_path:
@@ -516,50 +712,486 @@ def hol_interrupt() -> str:
     return "No HOL Light process running."
 
 
-@mcp.tool()
-def hol_restart() -> str:
-    """Kill and restart the HOL Light subprocess.
+def _reload_config():
+    """Reload the config file selected when the server started."""
+    if CONFIG_PATH is None:
+        return _effective_config({}, None)
+    if not os.path.isfile(CONFIG_PATH):
+        raise ValueError(f"Config file no longer exists: {CONFIG_PATH}")
+    import tomllib
+    try:
+        with open(CONFIG_PATH, "rb") as config_file:
+            config = tomllib.load(config_file)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ValueError(f"Unable to load config {CONFIG_PATH}: {exc}") from exc
+    return _effective_config(config, CONFIG_PATH)
 
-    Use when HOL Light has died or is in a bad state.
-    Any in-progress proof state will be lost.
-    """
-    global _proc, _helpers_loaded
-    with _lock:
-        if _proc is not None:
-            try:
-                _proc.kill()
-                _proc.wait(timeout=5)
-            except Exception:
-                pass
-            _proc = None
-        _helpers_loaded = False
-        global _recording_flushed
-        _recording_flushed = len(_recording)
-        _drain_queue()
-        _reader_buf.clear()
-        _start_hol()
+
+def _config_changes(previous, current):
+    changes = {}
+    previous = _config_snapshot(previous)
+    current = _config_snapshot(current)
+    for key in previous:
+        if previous[key] != current[key]:
+            changes[key] = {"old": previous[key], "new": current[key]}
+    return changes
+
+
+def _apply_runtime_config(config):
+    global _config, _runtime_config, TIMEOUT, MAX_OUTPUT_CHARS
+    global CONFIGURED_CHECKPOINT, _auto_record_dir
+    _config = config["raw"]
+    _runtime_config = config
+    TIMEOUT = config["timeout"]
+    MAX_OUTPUT_CHARS = config["max_output_chars"]
+    CONFIGURED_CHECKPOINT = config["checkpoint"]
+    _auto_record_dir = config["recording_dir"]
+
+
+def _process_alive():
+    return _proc is not None and _proc.poll() is None
+
+
+def _terminate_hol():
+    global _proc
+    proc = _proc
+    if proc is None:
+        return
+    try:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=5)
+    except Exception:
+        pass
+    _proc = None
+
+
+def _prepare_process_restart():
+    global _helpers_loaded, _recording_flushed
+    _helpers_loaded = False
+    _recording_flushed = len(_recording)
+    _drain_queue()
+    _reader_buf.clear()
+
+
+def _quarantine_hol(error):
+    """Stop stale HOL state after a forced rebuild failure."""
+    global _restart_required, _restart_error, _startup_mode
+    global _checkpoint_active, _checkpoint_error, _checkpoint_fingerprint
+    _terminate_hol()
+    _prepare_process_restart()
+    _restart_required = True
+    _restart_error = str(error)
+    _startup_mode = None
+    _checkpoint_active = False
+    _checkpoint_error = str(error)
+    _checkpoint_fingerprint = None
+
+
+def _clear_restart_requirement():
+    global _restart_required, _restart_error
+    _restart_required = False
+    _restart_error = None
+
+
+def _restart_process(checkpoint):
+    """Replace the process, falling back to a usable cold HOL on restore errors."""
+    global _proc
+    _terminate_hol()
+    _prepare_process_restart()
+
+    restore_error = None
+    try:
+        _start_hol(checkpoint, allow_restart_required=True)
         _load_helpers()
-    return "HOL Light restarted."
+    except Exception as exc:
+        if _checkpoint_active:
+            restore_error = f"Checkpoint restore failed: {exc}"
+        else:
+            return False, str(exc)
+
+    if restore_error is None and _startup_mode == "cold" and _checkpoint_error:
+        return False, _checkpoint_error
+
+    if restore_error is None:
+        return True, None
+
+    _terminate_hol()
+    _prepare_process_restart()
+    try:
+        _start_hol(
+            checkpoint,
+            force_cold=True,
+            checkpoint_error=restore_error,
+            allow_restart_required=True,
+        )
+        _load_helpers()
+    except Exception as exc:
+        return False, f"{restore_error}; cold start also failed: {exc}"
+    return False, restore_error
+
+
+def _run_restart_command(command, stage):
+    try:
+        result = subprocess.run(
+            command,
+            cwd=HOL_DIR,
+            env=_opam_env(),
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"{stage} could not start: {exc}") from exc
+    if result.returncode != 0:
+        output = "\n".join(
+            part.strip() for part in (result.stdout, result.stderr) if part.strip()
+        )
+        if len(output) > 4000:
+            output = output[-4000:]
+        raise RuntimeError(
+            f"{stage} failed with exit code {result.returncode}"
+            + (f":\n{output}" if output else "")
+        )
+
+
+def _build_checkpoint(checkpoint, recipe):
+    stage_dir = tempfile.mkdtemp(
+        prefix=f".hol-{checkpoint}.ckpt.", dir=HOL_DIR
+    )
+    shutil.rmtree(stage_dir)
+    command = [
+        sys.executable,
+        os.path.join(MCP_DIR, "make_checkpoint.py"),
+        "--name",
+        checkpoint,
+        "--output-dir",
+        stage_dir,
+    ]
+    for include_dir in recipe["include_dirs"]:
+        command.extend(["-I", include_dir])
+    command.extend(recipe["loads"])
+    try:
+        _run_restart_command(command, "checkpoint creation")
+        if not _checkpoint_files_in_dir(stage_dir):
+            raise RuntimeError(
+                f"Checkpoint creation produced no usable files in {stage_dir}"
+            )
+        return stage_dir
+    except Exception:
+        if os.path.exists(stage_dir):
+            shutil.rmtree(stage_dir, ignore_errors=True)
+        raise
+
+
+def _checkpoint_files_in_dir(path):
+    if not os.path.isdir(path):
+        return []
+    return sorted(
+        os.path.join(path, filename)
+        for filename in os.listdir(path)
+        if filename.startswith("ckpt_") and filename.endswith(".dmtcp")
+    )
+
+
+def _install_checkpoint(checkpoint, staged_dir):
+    """Move a staged checkpoint into place, replacing any existing one.
+
+    On failure the caller quarantines HOL and requires a fresh rebuild, so we
+    do not attempt to preserve or roll back to the previous checkpoint.
+    """
+    final_dir = _checkpoint_dir(checkpoint)
+    try:
+        if os.path.exists(final_dir):
+            shutil.rmtree(final_dir)
+        os.replace(staged_dir, final_dir)
+    except Exception as install_exc:
+        return False, f"Unable to install rebuilt checkpoint: {install_exc}"
+
+    if not _checkpoint_files(checkpoint):
+        return False, "Installed checkpoint contains no usable files"
+    return True, None
+
+
+def _restart_response(
+    started, previous_pid, checkpoint, checkpoint_overridden,
+    rebuild_hol_and_checkpoint, changes
+):
+    return {
+        "success": False,
+        "rebuild_hol_and_checkpoint": rebuild_hol_and_checkpoint,
+        "rebuilt": False,
+        "config_reloaded": False,
+        "checkpoint": checkpoint,
+        "configured_checkpoint": CONFIGURED_CHECKPOINT,
+        "checkpoint_overridden": checkpoint_overridden,
+        "previous_pid": previous_pid,
+        "pid": _proc.pid if _process_alive() else None,
+        "startup_mode": _startup_mode,
+        "elapsed_seconds": round(time.monotonic() - started, 3),
+        "config_changes": changes,
+    }
+
+
+def _hol_restart_sync(checkpoint, rebuild_hol_and_checkpoint, progress):
+    started = time.monotonic()
+    previous_pid = _proc.pid if _process_alive() else None
+    old_process_alive = _process_alive()
+    selected = checkpoint or CONFIGURED_CHECKPOINT
+    checkpoint_overridden = checkpoint is not None
+    changes = {}
+
+    with _restart_lock:
+        progress("config_validation", "Reloading and validating configuration")
+        try:
+            new_config = _reload_config()
+            selected = _validate_checkpoint_name(
+                checkpoint if checkpoint is not None else new_config["checkpoint"]
+            )
+            changes = _config_changes(_runtime_config, new_config)
+            if _restart_required and not rebuild_hol_and_checkpoint:
+                raise ValueError(
+                    "A previous HOL/checkpoint rebuild failed. Fix the build "
+                    "and run hol_restart(rebuild_hol_and_checkpoint=true) "
+                    "before continuing."
+                )
+            if new_config["recording_dir"] != _auto_record_dir:
+                raise ValueError(
+                    "recording_dir cannot be changed by hol_restart; "
+                    "the existing HOL process and recording were preserved"
+                )
+            recipe = new_config["checkpoint_recipes"].get(selected)
+            if rebuild_hol_and_checkpoint and recipe is None:
+                if selected == "base":
+                    # "base" is canonically vanilla HOL Light, so it can be
+                    # rebuilt without an explicit recipe. Any other checkpoint
+                    # must define one; we never rebuild a custom checkpoint as
+                    # bare HOL and silently swap it in.
+                    recipe = {"include_dirs": [], "loads": []}
+                else:
+                    raise ValueError(
+                        "rebuild_hol_and_checkpoint=True requires "
+                        f"checkpoint_recipes.{selected} (only the \"base\" "
+                        "checkpoint can be rebuilt without an explicit recipe)"
+                    )
+            if rebuild_hol_and_checkpoint:
+                missing = [
+                    path for path in recipe["include_dirs"]
+                    if not os.path.isdir(path)
+                ]
+                if missing:
+                    raise ValueError(
+                        "Checkpoint recipe include directories do not exist: "
+                        + ", ".join(missing)
+                    )
+        except Exception as exc:
+            response = _restart_response(
+                started, previous_pid, selected, checkpoint_overridden,
+                rebuild_hol_and_checkpoint, changes
+            )
+            response.update({
+                "stage": "config_validation",
+                "error": str(exc),
+                "hol_preserved": old_process_alive and _process_alive(),
+            })
+            response["elapsed_seconds"] = round(time.monotonic() - started, 3)
+            return response
+
+        _apply_runtime_config(new_config)
+        staged_dir = None
+        if rebuild_hol_and_checkpoint:
+            failure_stage = "clean"
+            try:
+                progress("clean", "Running make clean")
+                _run_restart_command(["make", "clean"], "make clean")
+                failure_stage = "build"
+                progress("build", "Building HOL Light")
+                _run_restart_command(["make"], "make")
+                failure_stage = "checkpoint_creation"
+                progress(
+                    "checkpoint_creation",
+                    f"Creating checkpoint {selected}",
+                )
+                staged_dir = _build_checkpoint(selected, recipe)
+            except Exception as exc:
+                with _lock:
+                    _quarantine_hol(exc)
+                response = _restart_response(
+                    started, previous_pid, selected, checkpoint_overridden,
+                    rebuild_hol_and_checkpoint, changes
+                )
+                response.update({
+                    "config_reloaded": True,
+                    "stage": failure_stage,
+                    "error": str(exc),
+                    "hol_preserved": False,
+                })
+                response["pid"] = None
+                response["startup_mode"] = None
+                response["elapsed_seconds"] = round(time.monotonic() - started, 3)
+                return response
+
+        progress("restart", f"Restarting HOL with checkpoint {selected}")
+        with _lock:
+            if rebuild_hol_and_checkpoint:
+                installed, install_error = _install_checkpoint(
+                    selected, staged_dir
+                )
+                if not installed:
+                    if staged_dir and os.path.exists(staged_dir):
+                        shutil.rmtree(staged_dir, ignore_errors=True)
+                    _quarantine_hol(install_error)
+                    response = _restart_response(
+                        started, previous_pid, selected, checkpoint_overridden,
+                        rebuild_hol_and_checkpoint, changes
+                    )
+                    response.update({
+                        "config_reloaded": True,
+                        "stage": "checkpoint_install",
+                        "error": install_error,
+                        "hol_preserved": False,
+                    })
+                    response["pid"] = None
+                    response["startup_mode"] = None
+                    response["elapsed_seconds"] = round(
+                        time.monotonic() - started, 3
+                    )
+                    return response
+
+                _clear_restart_requirement()
+            success, restart_error = _restart_process(selected)
+
+        response = _restart_response(
+            started, previous_pid, selected, checkpoint_overridden,
+            rebuild_hol_and_checkpoint, changes
+        )
+        response.update({
+            "success": success,
+            "rebuilt": rebuild_hol_and_checkpoint,
+            "config_reloaded": True,
+            "hol_preserved": False,
+        })
+        if not success:
+            response.update({
+                "stage": "restart",
+                "error": restart_error or "HOL Light restart failed",
+            })
+        response["pid"] = _proc.pid if _process_alive() else None
+        response["startup_mode"] = _startup_mode
+        response["elapsed_seconds"] = round(time.monotonic() - started, 3)
+        return response
+
+
+@mcp.tool()
+async def hol_restart(
+    checkpoint: str | None = None,
+    rebuild_hol_and_checkpoint: bool = False,
+    ctx: Context = None,
+) -> str:
+    """Reload configuration and restart the HOL Light subprocess.
+
+    Args:
+        checkpoint: Optional checkpoint override for this restart only.
+        rebuild_hol_and_checkpoint: Run make clean and make to rebuild HOL
+            Light from source, then rebuild the selected checkpoint, before
+            restarting. This is a heavy, multi-minute operation, so it must be
+            requested explicitly.
+
+    Rebuilding HOL Light and its checkpoint commonly takes several minutes. The
+    existing HOL process remains alive until the build and checkpoint creation
+    have succeeded.
+    """
+    events = queue.SimpleQueue()
+    executor = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="hol-restart"
+    )
+    future = executor.submit(
+        _hol_restart_sync,
+        checkpoint,
+        rebuild_hol_and_checkpoint,
+        lambda stage, message: events.put((stage, message)),
+    )
+    current_stage = None
+    stage_started = time.monotonic()
+    last_heartbeat = stage_started
+    progress_numbers = {
+        "config_validation": 1,
+        "clean": 2,
+        "build": 3,
+        "checkpoint_creation": 4,
+        "restart": 5,
+    }
+
+    try:
+        while not future.done():
+            while True:
+                try:
+                    stage, message = events.get_nowait()
+                except queue.Empty:
+                    break
+                current_stage = stage
+                stage_started = time.monotonic()
+                last_heartbeat = stage_started
+                if ctx is not None:
+                    await ctx.report_progress(
+                        progress_numbers[stage], 5, message
+                    )
+            now = time.monotonic()
+            if (
+                ctx is not None
+                and current_stage is not None
+                and now - last_heartbeat >= RESTART_HEARTBEAT_SECONDS
+            ):
+                elapsed = round(now - stage_started)
+                await ctx.report_progress(
+                    progress_numbers[current_stage],
+                    5,
+                    f"{current_stage.replace('_', ' ')}: {elapsed}s elapsed",
+                )
+                last_heartbeat = now
+            await asyncio.sleep(0.25)
+
+        result = future.result()
+    finally:
+        executor.shutdown(wait=future.done())
+    while True:
+        try:
+            stage, message = events.get_nowait()
+        except queue.Empty:
+            break
+        if ctx is not None:
+            await ctx.report_progress(progress_numbers[stage], 5, message)
+    return json.dumps(result)
 
 
 @mcp.tool()
 def hol_status() -> str:
     """Check whether the HOL Light subprocess is alive.
 
-    Returns JSON: {"alive": bool, "pid": int|null, "checkpoint": str,
-                   "config": str|null, "uptime_seconds": float|null,
-                   "timeout": int, "max_output_chars": int}
+    Returns JSON with process health, active and configured checkpoints,
+    startup mode, checkpoint fingerprint/staleness, and runtime limits.
     """
-    import json
     alive = _proc is not None and _proc.poll() is None
+    current_fingerprint = _fingerprint_checkpoint(CHECKPOINT_NAME)
+    checkpoint_stale = (
+        _checkpoint_fingerprint is not None
+        and current_fingerprint != _checkpoint_fingerprint
+    )
     return json.dumps({
         "alive": alive,
         "pid": _proc.pid if alive else None,
         "checkpoint": CHECKPOINT_NAME,
+        "configured_checkpoint": CONFIGURED_CHECKPOINT,
         "config": CONFIG_PATH,
         "uptime_seconds": round(time.time() - _start_time, 1) if alive and _start_time else None,
         "timeout": TIMEOUT,
         "max_output_chars": MAX_OUTPUT_CHARS,
+        "startup_mode": _startup_mode,
+        "checkpoint_active": _checkpoint_active,
+        "checkpoint_error": _checkpoint_error,
+        "checkpoint_fingerprint": _checkpoint_fingerprint,
+        "checkpoint_stale": checkpoint_stale,
+        "restart_required": _restart_required,
+        "restart_error": _restart_error,
     })
 
 

--- a/mcp/smoke_test.py
+++ b/mcp/smoke_test.py
@@ -161,7 +161,16 @@ async def main():
 
             # hol_restart (run last — kills the process)
             r = await session.call_tool("hol_restart", {})
-            check("hol_restart", "restarted" in r.content[0].text.lower(), r.content[0].text)
+            restart = json.loads(r.content[0].text)
+            check(
+                "hol_restart",
+                restart["success"] is True
+                or (
+                    restart["startup_mode"] == "cold"
+                    and "No usable checkpoint" in restart.get("error", "")
+                ),
+                str(restart),
+            )
             r = await session.call_tool("eval", {"code": "1 + 1"})
             ev = json.loads(r.content[0].text)
             check("eval after restart", "2" in ev["output"], ev["output"])

--- a/mcp/test_restart.py
+++ b/mcp/test_restart.py
@@ -1,0 +1,460 @@
+"""Focused tests for config-aware HOL restarts."""
+
+import asyncio
+import json
+import os
+import time
+
+import pytest
+
+import server
+
+
+class FakeProcess:
+    def __init__(self, pid=1234):
+        self.pid = pid
+        self.alive = True
+
+    def poll(self):
+        return None if self.alive else 0
+
+    def kill(self):
+        self.alive = False
+
+    def wait(self, timeout=None):
+        self.alive = False
+        return 0
+
+
+def make_config(tmp_path, checkpoint="base", **values):
+    raw = {
+        "checkpoint": checkpoint,
+        "timeout": values.pop("timeout", 600),
+        "max_output_chars": values.pop("max_output_chars", 4000),
+        "checkpoint_recipes": values.pop("checkpoint_recipes", {
+            "base": {"include_dirs": [], "loads": []},
+        }),
+    }
+    raw.update(values)
+    return server._effective_config(raw, str(tmp_path / "hol-mcp.toml"))
+
+
+@pytest.fixture(autouse=True)
+def restore_runtime():
+    runtime = server._runtime_config
+    checkpoint_name = server.CHECKPOINT_NAME
+    startup_mode = server._startup_mode
+    checkpoint_active = server._checkpoint_active
+    checkpoint_error = server._checkpoint_error
+    checkpoint_fingerprint = server._checkpoint_fingerprint
+    restart_required = server._restart_required
+    restart_error = server._restart_error
+    proc = server._proc
+    yield
+    server._apply_runtime_config(runtime)
+    server.CHECKPOINT_NAME = checkpoint_name
+    server._startup_mode = startup_mode
+    server._checkpoint_active = checkpoint_active
+    server._checkpoint_error = checkpoint_error
+    server._checkpoint_fingerprint = checkpoint_fingerprint
+    server._restart_required = restart_required
+    server._restart_error = restart_error
+    server._proc = proc
+
+
+def test_config_reload_and_one_shot_override(monkeypatch, tmp_path):
+    config = make_config(
+        tmp_path,
+        checkpoint="gcm",
+        timeout=321,
+        max_output_chars=987,
+        checkpoint_recipes={
+            "base": {"include_dirs": [], "loads": []},
+            "gcm": {"include_dirs": [], "loads": []},
+        },
+    )
+    selected = []
+    monkeypatch.setattr(server, "_reload_config", lambda: config)
+    monkeypatch.setattr(
+        server, "_restart_process",
+        lambda checkpoint: (selected.append(checkpoint) is None, None),
+    )
+    monkeypatch.setattr(server, "_proc", FakeProcess())
+
+    overridden = server._hol_restart_sync("base", False, lambda *_: None)
+    configured = server._hol_restart_sync(None, False, lambda *_: None)
+
+    assert overridden["success"] is True
+    assert overridden["checkpoint"] == "base"
+    assert overridden["configured_checkpoint"] == "gcm"
+    assert overridden["checkpoint_overridden"] is True
+    assert configured["checkpoint"] == "gcm"
+    assert configured["checkpoint_overridden"] is False
+    assert selected == ["base", "gcm"]
+    assert server.TIMEOUT == 321
+    assert server.MAX_OUTPUT_CHARS == 987
+
+
+def test_rebuild_requires_recipe(monkeypatch, tmp_path):
+    config = make_config(tmp_path, checkpoint="unbuilt", checkpoint_recipes={})
+    proc = FakeProcess()
+    monkeypatch.setattr(server, "_reload_config", lambda: config)
+    monkeypatch.setattr(server, "_proc", proc)
+
+    result = server._hol_restart_sync(None, True, lambda *_: None)
+
+    assert result["success"] is False
+    assert result["stage"] == "config_validation"
+    assert "checkpoint_recipes.unbuilt" in result["error"]
+    # The failure explains that only "base" is exempt from needing a recipe.
+    assert "base" in result["error"]
+    assert result["hol_preserved"] is True
+    assert proc.alive is True
+
+
+def test_base_rebuilds_without_explicit_recipe(monkeypatch, tmp_path):
+    # "base" is vanilla HOL Light: it can be rebuilt even when the config
+    # defines no checkpoint_recipes (e.g. an older hol-mcp.toml).
+    config = make_config(tmp_path, checkpoint="base", checkpoint_recipes={})
+    commands = []
+
+    def run_command(command, stage):
+        commands.append(command)
+        if "--output-dir" in command:
+            output_dir = command[command.index("--output-dir") + 1]
+            os.makedirs(output_dir)
+            open(os.path.join(output_dir, "ckpt_test.dmtcp"), "wb").close()
+
+    monkeypatch.setattr(server, "HOL_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_reload_config", lambda: config)
+    monkeypatch.setattr(server, "_run_restart_command", run_command)
+    monkeypatch.setattr(server, "_install_checkpoint", lambda *_: (True, None))
+    monkeypatch.setattr(server, "_restart_process", lambda _: (True, None))
+    monkeypatch.setattr(server, "_proc", FakeProcess())
+
+    result = server._hol_restart_sync(None, True, lambda *_: None)
+
+    assert result["success"] is True
+    assert result["rebuilt"] is True
+    # The base recipe carries no include dirs or extra loads.
+    checkpoint_command = commands[2]
+    assert checkpoint_command[checkpoint_command.index("--name") + 1] == "base"
+    assert "-I" not in checkpoint_command
+    # Nothing follows --output-dir <dir> (no loads appended).
+    assert checkpoint_command[-2] == "--output-dir"
+
+
+def test_config_without_checkpoint_recipes_key_defaults_to_empty(tmp_path):
+    # Backward compat: an older hol-mcp.toml has no [checkpoint_recipes].
+    # Parsing must not crash and recipes must default to an empty table.
+    config = server._effective_config(
+        {"checkpoint": "base", "timeout": 600, "max_output_chars": 4000},
+        str(tmp_path / "hol-mcp.toml"),
+    )
+    assert config["checkpoint_recipes"] == {}
+
+
+def test_reload_without_recipes_still_restarts(monkeypatch, tmp_path):
+    # A plain restart (no rebuild) must work against a recipe-less config.
+    config = server._effective_config(
+        {"checkpoint": "base"}, str(tmp_path / "hol-mcp.toml")
+    )
+    proc = FakeProcess()
+    monkeypatch.setattr(server, "_reload_config", lambda: config)
+    monkeypatch.setattr(server, "_restart_process", lambda _: (True, None))
+    monkeypatch.setattr(server, "_proc", proc)
+
+    result = server._hol_restart_sync(None, False, lambda *_: None)
+
+    assert result["success"] is True
+    assert result["config_reloaded"] is True
+
+
+def test_hol_status_survives_missing_recipes(monkeypatch, tmp_path):
+    # hol_status never consults checkpoint_recipes, so an old config that
+    # lacks them must not crash it.
+    config = server._effective_config(
+        {"checkpoint": "base"}, str(tmp_path / "hol-mcp.toml")
+    )
+    server._apply_runtime_config(config)
+    monkeypatch.setattr(server, "_proc", None)
+
+    status = json.loads(server.hol_status())
+
+    assert status["alive"] is False
+    assert status["configured_checkpoint"] == "base"
+
+
+def test_relative_recipe_paths_use_config_directory(tmp_path):
+    config_dir = tmp_path / "project"
+    config_dir.mkdir()
+    config = server._effective_config(
+        {
+            "checkpoint": "gcm",
+            "checkpoint_recipes": {
+                "gcm": {
+                    "include_dirs": ["../s2n-bignum"],
+                    "loads": ['needs "common/gcm.ml"'],
+                }
+            },
+        },
+        str(config_dir / "hol-mcp.toml"),
+    )
+
+    assert config["checkpoint_recipes"]["gcm"]["include_dirs"] == [
+        str(tmp_path / "s2n-bignum")
+    ]
+
+
+def test_rebuild_orders_build_and_checkpoint_recipe(monkeypatch, tmp_path):
+    include_dir = tmp_path / "s2n"
+    include_dir.mkdir()
+    config = make_config(
+        tmp_path,
+        checkpoint="gcm",
+        checkpoint_recipes={
+            "gcm": {
+                "include_dirs": [str(include_dir)],
+                "loads": ['needs "arm/proofs/base.ml"', 'needs "common/gcm.ml"'],
+            }
+        },
+    )
+    commands = []
+
+    def run_command(command, stage):
+        commands.append(command)
+        if "--output-dir" in command:
+            output_dir = command[command.index("--output-dir") + 1]
+            os.makedirs(output_dir)
+            (open(os.path.join(output_dir, "ckpt_test.dmtcp"), "wb")).close()
+
+    monkeypatch.setattr(server, "HOL_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_reload_config", lambda: config)
+    monkeypatch.setattr(server, "_run_restart_command", run_command)
+    monkeypatch.setattr(
+        server, "_install_checkpoint", lambda *_: (True, None)
+    )
+    monkeypatch.setattr(server, "_restart_process", lambda _: (True, None))
+    monkeypatch.setattr(server, "_proc", FakeProcess())
+    monkeypatch.setattr(server, "_restart_required", True)
+    monkeypatch.setattr(server, "_restart_error", "previous build failed")
+
+    result = server._hol_restart_sync(None, True, lambda *_: None)
+
+    assert result["success"] is True
+    assert result["rebuilt"] is True
+    assert server._restart_required is False
+    assert commands[0] == ["make", "clean"]
+    assert commands[1] == ["make"]
+    checkpoint_command = commands[2]
+    assert checkpoint_command[checkpoint_command.index("-I") + 1] == str(include_dir)
+    assert checkpoint_command[-2:] == [
+        'needs "arm/proofs/base.ml"',
+        'needs "common/gcm.ml"',
+    ]
+
+
+def test_build_failure_quarantines_hol_and_preserves_checkpoint(
+    monkeypatch, tmp_path
+):
+    checkpoint_dir = tmp_path / "hol-base.ckpt"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "ckpt_old.dmtcp"
+    checkpoint_file.write_bytes(b"old")
+    config = make_config(tmp_path)
+    proc = FakeProcess()
+
+    def fail_build(command, stage):
+        if command == ["make"]:
+            raise RuntimeError("build failed")
+
+    monkeypatch.setattr(server, "HOL_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_reload_config", lambda: config)
+    monkeypatch.setattr(server, "_run_restart_command", fail_build)
+    monkeypatch.setattr(server, "_proc", proc)
+
+    result = server._hol_restart_sync(None, True, lambda *_: None)
+
+    assert result["success"] is False
+    assert result["stage"] == "build"
+    assert result["hol_preserved"] is False
+    assert result["pid"] is None
+    assert proc.alive is False
+    assert server._restart_required is True
+    assert checkpoint_file.read_bytes() == b"old"
+    with pytest.raises(RuntimeError, match="failed HOL/checkpoint rebuild"):
+        server._start_hol()
+
+    retry = server._hol_restart_sync(None, False, lambda *_: None)
+    assert retry["success"] is False
+    assert "hol_restart(rebuild_hol_and_checkpoint=true)" in retry["error"]
+
+
+def test_checkpoint_generation_failure_quarantines_hol(
+    monkeypatch, tmp_path
+):
+    checkpoint_dir = tmp_path / "hol-base.ckpt"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "ckpt_old.dmtcp"
+    checkpoint_file.write_bytes(b"old")
+    config = make_config(tmp_path)
+    proc = FakeProcess()
+
+    def fail_generation(command, stage):
+        if "--output-dir" in command:
+            raise RuntimeError("checkpoint generation failed")
+
+    monkeypatch.setattr(server, "HOL_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_reload_config", lambda: config)
+    monkeypatch.setattr(server, "_run_restart_command", fail_generation)
+    monkeypatch.setattr(server, "_proc", proc)
+
+    result = server._hol_restart_sync(None, True, lambda *_: None)
+
+    assert result["success"] is False
+    assert result["stage"] == "checkpoint_creation"
+    assert result["hol_preserved"] is False
+    assert proc.alive is False
+    assert server._restart_required is True
+    assert checkpoint_file.read_bytes() == b"old"
+
+
+def test_checkpoint_install_failure_reports_error_without_rollback(
+    monkeypatch, tmp_path
+):
+    # Install does not roll back on failure: the caller quarantines HOL and
+    # requires a fresh rebuild, so a failed install just reports the error.
+    final_dir = tmp_path / "hol-base.ckpt"
+    final_dir.mkdir()
+    (final_dir / "ckpt_old.dmtcp").write_bytes(b"old")
+    staged_dir = tmp_path / ".staged"
+    staged_dir.mkdir()
+    (staged_dir / "ckpt_new.dmtcp").write_bytes(b"new")
+
+    def fail_install(source, destination):
+        raise OSError("simulated install failure")
+
+    monkeypatch.setattr(server, "HOL_DIR", str(tmp_path))
+    monkeypatch.setattr(server.os, "replace", fail_install)
+
+    installed, error = server._install_checkpoint("base", str(staged_dir))
+
+    assert installed is False
+    assert "simulated install failure" in error
+
+
+def test_recording_dir_change_rejected_without_side_effects(
+    monkeypatch, tmp_path
+):
+    config = make_config(tmp_path, recording_dir=str(tmp_path / "new"))
+    proc = FakeProcess()
+    restarted = False
+
+    def restart(_):
+        nonlocal restarted
+        restarted = True
+        return True, None
+
+    monkeypatch.setattr(server, "_reload_config", lambda: config)
+    monkeypatch.setattr(server, "_restart_process", restart)
+    monkeypatch.setattr(server, "_proc", proc)
+
+    result = server._hol_restart_sync(None, False, lambda *_: None)
+
+    assert result["success"] is False
+    assert result["stage"] == "config_validation"
+    assert result["hol_preserved"] is True
+    assert restarted is False
+    assert proc.alive is True
+
+
+def test_install_failure_quarantines_hol(monkeypatch, tmp_path):
+    config = make_config(tmp_path)
+    proc = FakeProcess()
+    monkeypatch.setattr(server, "HOL_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "_reload_config", lambda: config)
+    monkeypatch.setattr(server, "_run_restart_command", lambda *_: None)
+    monkeypatch.setattr(
+        server,
+        "_build_checkpoint",
+        lambda *_: str(tmp_path / ".staged"),
+    )
+    monkeypatch.setattr(
+        server,
+        "_install_checkpoint",
+        lambda *_: (False, "install failed"),
+    )
+
+    monkeypatch.setattr(server, "_proc", proc)
+
+    result = server._hol_restart_sync(None, True, lambda *_: None)
+
+    assert result["success"] is False
+    assert result["stage"] == "checkpoint_install"
+    assert result["hol_preserved"] is False
+    assert result["startup_mode"] is None
+    assert result["pid"] is None
+    assert proc.alive is False
+    assert server._restart_required is True
+
+
+def test_status_detects_replaced_checkpoint(monkeypatch, tmp_path):
+    checkpoint_dir = tmp_path / "hol-base.ckpt"
+    checkpoint_dir.mkdir()
+    checkpoint_file = checkpoint_dir / "ckpt_one.dmtcp"
+    checkpoint_file.write_bytes(b"first")
+    monkeypatch.setattr(server, "HOL_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "CHECKPOINT_NAME", "base")
+    monkeypatch.setattr(
+        server, "_checkpoint_fingerprint",
+        server._fingerprint_checkpoint("base"),
+    )
+
+    checkpoint_file.write_bytes(b"replacement")
+    status = json.loads(server.hol_status())
+
+    assert status["checkpoint_stale"] is True
+    assert status["checkpoint_fingerprint"][0]["name"] == "ckpt_one.dmtcp"
+    assert isinstance(status["restart_required"], bool)
+
+
+def test_progress_milestones_and_heartbeat(monkeypatch):
+    class FakeContext:
+        def __init__(self):
+            self.reports = []
+
+        async def report_progress(self, progress, total=None, message=None):
+            self.reports.append((progress, total, message))
+
+    def slow_restart(checkpoint, rebuild_hol_and_checkpoint, progress):
+        for stage in (
+            "config_validation",
+            "clean",
+            "build",
+            "checkpoint_creation",
+            "restart",
+        ):
+            progress(stage, stage)
+        time.sleep(0.6)
+        return {"success": True}
+
+    context = FakeContext()
+    monkeypatch.setattr(server, "_hol_restart_sync", slow_restart)
+    monkeypatch.setattr(server, "RESTART_HEARTBEAT_SECONDS", 0.05)
+
+    result = json.loads(
+        asyncio.run(
+            server.hol_restart(rebuild_hol_and_checkpoint=True, ctx=context)
+        )
+    )
+    messages = [report[2] for report in context.reports]
+
+    assert result["success"] is True
+    assert set(messages[:5]) == {
+        "config_validation",
+        "clean",
+        "build",
+        "checkpoint_creation",
+        "restart",
+    }
+    assert any("elapsed" in message for message in messages)

--- a/mcp/test_server.py
+++ b/mcp/test_server.py
@@ -5,6 +5,7 @@ shared across all tests via module-scoped fixture.
 """
 
 import json
+import asyncio
 import os
 import pytest
 import server
@@ -134,6 +135,16 @@ def test_hol_status_alive():
     assert result["uptime_seconds"] > 0
     assert isinstance(result["timeout"], int)
     assert isinstance(result["max_output_chars"], int)
+    assert isinstance(result["configured_checkpoint"], str)
+    assert result["startup_mode"] in {"checkpoint", "cold"}
+    assert isinstance(result["checkpoint_active"], bool)
+    assert result["checkpoint_error"] is None or isinstance(result["checkpoint_error"], str)
+    assert result["checkpoint_fingerprint"] is None or isinstance(
+        result["checkpoint_fingerprint"], list
+    )
+    assert isinstance(result["checkpoint_stale"], bool)
+    assert isinstance(result["restart_required"], bool)
+    assert result["restart_error"] is None or isinstance(result["restart_error"], str)
 
 
 def test_hol_status_reports_checkpoint_name():
@@ -158,15 +169,20 @@ def test_apply_tactic_with_custom_timeout():
 def test_eval_timeout_expires():
     r = json.loads(server.eval("let rec loop () = loop () in loop ()", timeout=1))
     assert r["success"] is False or "timeout" in r["output"].lower()
-    server.hol_restart()
+    asyncio.run(server.hol_restart())
 
 
 # --- hol_restart ---
 
 def test_hol_restart():
     old_pid = server._proc.pid
-    result = server.hol_restart()
-    assert "restarted" in result.lower()
+    result = json.loads(asyncio.run(server.hol_restart()))
+    if result["success"] is False:
+        assert result["startup_mode"] == "cold"
+        assert "No usable checkpoint" in result["error"]
+    assert result["previous_pid"] == old_pid
+    assert result["pid"] != old_pid
+    assert result["config_reloaded"] is True
     assert server._proc.poll() is None
     assert server._proc.pid != old_pid
     r = json.loads(server.eval("1 + 1"))


### PR DESCRIPTION
Reworks the MCP server's `hol_restart` from a bare kill/restart into a config-aware restart, so an agent editing an underlying source file can refresh its environment without dropping the session.

`hol_restart` now reloads `hol-mcp.toml`, accepts a one-shot `checkpoint=` override, and (with `rebuild_hol_and_checkpoint=true`) can rebuild HOL Light and the selected checkpoint in place. `hol_status` gains active-vs-configured checkpoint, startup mode, and stale-checkpoint reporting. See README/hol-mcp.toml for the config format and semantics.

**This is fully backward compatible:** existing `hol-mcp.toml` files and every current `hol_restart`/`hol_status` behavior are unchanged. The new behavior is entirely opt-in via new arguments, so no existing HOL Light user is affected.

**Testing.** New `test_restart.py` covers reload, override, recipe validation, failure handling/quarantine, and progress reporting; `test_server.py`/`smoke_test.py` and CI are updated. Verified from a clean build (OCaml 5.4.0): 63 unit tests and 37/37 smoke checks pass.

**For Reviewers:**
- The rebuild shells out to `make clean`/`make` and replaces checkpoint files. It is gated behind an explicit, non-default flag, builds into a temp dir so a failed build never touches the live checkpoint, and on any later failure quarantines HOL Light (rejecting proof work with a recovery message) rather than falling back to a stale checkpoint.
- Only the `base` checkpoint may be rebuilt without a recipe; any other checkpoint without a `[checkpoint_recipes.<name>]` entry fails, so a custom checkpoint is never silently rebuilt as bare HOL Light. Defining a recipe is the only reason to touch an existing config.